### PR TITLE
Subtitle file for MISP Training Video during FIRST

### DIFF
--- a/x.15-subtitles/MISP General Usage Training - Part 1 of 2.srt
+++ b/x.15-subtitles/MISP General Usage Training - Part 1 of 2.srt
@@ -1,0 +1,20701 @@
+1
+00:00:00,880 --> 00:00:04,719
+and I'll pass over the mic all right
+
+2
+00:00:02,638 --> 00:00:07,278
+thank you
+
+3
+00:00:04,719 --> 00:00:09,599
+yeah great, good morning good afternoon
+
+4
+00:00:07,278 --> 00:00:12,719
+and even good evening for some of you
+
+5
+00:00:09,599 --> 00:00:14,879
+um so um i'm really glad and uh
+
+6
+00:00:12,718 --> 00:00:16,480
+we are glad to present about MISP today
+
+7
+00:00:14,880 --> 00:00:18,719
+and so it's a
+
+8
+00:00:16,480 --> 00:00:20,240
+double series of workshops so we start
+
+9
+00:00:18,719 --> 00:00:20,799
+with a workshop of the introduction and
+
+10
+00:00:20,239 --> 00:00:22,799
+we go
+
+11
+00:00:20,800 --> 00:00:23,839
+more deeper tomorrow in that second
+
+12
+00:00:22,800 --> 00:00:26,160
+workshop
+
+13
+00:00:23,839 --> 00:00:27,359
+um i'm alexander noah i do work for
+
+14
+00:00:26,160 --> 00:00:30,640
+CIRCL and
+
+15
+00:00:27,359 --> 00:00:34,800
+i work in the MISP {inaudible}
+
+16
+00:00:30,640 --> 00:00:37,520
+so today uh the agenda is the following
+
+17
+00:00:34,799 --> 00:00:38,78
+uh we will do a quick introduction to
+
+18
+00:00:37,520 --> 00:00:41,920
+MISP
+
+19
+00:00:38,79 --> 00:00:43,679
+a kind of of one-hour sessions with
+
+20
+00:00:41,920 --> 00:00:46,239
+all the detail about MISP and then a
+
+21
+00:00:43,679 --> 00:00:49,359
+more like kind of usage deep dive
+
+22
+00:00:46,238 --> 00:00:52,558
+of one hour where we do hands-on together
+
+23
+00:00:49,359 --> 00:00:55,519
+um for the logistic aspect um
+
+24
+00:00:52,558 --> 00:00:55,839
+in the chat room we will share with you
+
+25
+00:00:55,520 --> 00:00:57,520
+uh
+
+26
+00:00:55,840 --> 00:00:59,520
+all the details how to access the MISP
+
+27
+00:00:57,520 --> 00:01:00,399
+instance so during the sessions in the
+
+28
+00:00:59,520 --> 00:01:02,239
+workshop
+
+29
+00:01:00,399 --> 00:01:03,840
+you can connect to a dedicated MISP
+
+30
+00:01:02,238 --> 00:01:05,840
+system that we set up for you
+
+31
+00:01:03,840 --> 00:01:07,680
+and this one will be used for all the
+
+32
+00:01:05,840 --> 00:01:10,79
+hands-on that we will
+
+33
+00:01:07,680 --> 00:01:12,240
+we do as i just mentioned we have a
+
+34
+00:01:10,79 --> 00:01:14,158
+small short break of 15 minutes
+
+35
+00:01:12,239 --> 00:01:15,679
+and then we will continue in the end
+
+36
+00:01:14,159 --> 00:01:18,960
+{inaudible}
+
+37
+00:01:15,680 --> 00:01:20,880
+depending of how far we are today uh
+
+38
+00:01:18,959 --> 00:01:22,959
+we will maybe talk about the community
+
+39
+00:01:20,879 --> 00:01:24,719
+building aspect but this is a topic for
+
+40
+00:01:22,959 --> 00:01:26,239
+tomorrow obviously
+
+41
+00:01:24,719 --> 00:01:28,640
+but if we have some time remaining we
+
+42
+00:01:26,239 --> 00:01:29,280
+might uh talk about this and then we
+
+43
+00:01:28,640 --> 00:01:31,920
+have a
+
+44
+00:01:29,280 --> 00:01:33,280
+q&a sessions uh to discuss about the
+
+45
+00:01:31,920 --> 00:01:35,359
+different {inaudible} and so on
+
+46
+00:01:33,280 --> 00:01:37,439
+so don't hesitate to to put your
+
+47
+00:01:35,359 --> 00:01:39,438
+question to zoom
+
+48
+00:01:37,438 --> 00:01:42,319
+uh directly and we will try to answer live
+
+50
+00:01:40,799 --> 00:01:45,600
+all those questions that you are asking  
+
+51
+00:01:42,319 --> 00:01:45,599
+during uh during this session
+
+52
+00:01:46,319 --> 00:01:50,239
+so first of all welcome all as well from
+
+53
+00:01:48,478 --> 00:01:53,519
+me so i'm Andras Iklody i'm
+
+54
+00:01:50,239 --> 00:01:56,798
+also working at CIRCL working on MISP
+
+55
+00:01:53,519 --> 00:01:57,280
+um to just kick things off um i think
+
+56
+00:01:56,799 --> 00:01:58,719
+it's a good
+
+57
+00:01:57,280 --> 00:02:00,79
+good moment to start a little bit about
+
+58
+00:01:58,718 --> 00:02:02,78
+the history of how this whole thing
+
+59
+00:02:00,78 --> 00:02:04,879
+started how MISP came about
+
+60
+00:02:02,78 --> 00:02:06,839
+so just a quick introduction of where we
+
+61
+00:02:04,879 --> 00:02:09,519
+came from and where where we are
+
+62
+00:02:06,840 --> 00:02:10,399
+nowadays uh initially this whole thing
+
+63
+00:02:09,520 --> 00:02:13,520
+for us with MISP
+
+64
+00:02:10,399 --> 00:02:14,959
+started as part of a of a series of
+
+65
+00:02:13,520 --> 00:02:17,360
+incidents that we had in
+
+66
+00:02:14,959 --> 00:02:19,759
+back in 2012 between national and
+
+67
+00:02:17,360 --> 00:02:22,480
+military CSIRTS at the time
+
+68
+00:02:19,759 --> 00:02:24,799
+where we were basically investigating umattacks
+
+70
+00:02:23,520 --> 00:02:27,120
+that were hitting several of the
+
+71
+00:02:24,800 --> 00:02:28,319
+institutions at the at the time
+
+72
+00:02:27,120 --> 00:02:30,400
+and one of the interesting things that
+
+73
+00:02:28,318 --> 00:02:31,759
+we found was that even though we had
+
+74
+00:02:30,400 --> 00:02:33,519
+something called the malware analysis
+
+75
+00:02:31,759 --> 00:02:35,120
+working group which was this which is a
+
+76
+00:02:33,519 --> 00:02:37,360
+group that was regularly meeting and
+
+77
+00:02:35,120 --> 00:02:39,680
+discussing ongoing incidents
+
+78
+00:02:37,360 --> 00:02:40,720
+we still had a massive gap in between
+
+79
+00:02:39,680 --> 00:02:42,80
+those meetings
+
+80
+00:02:40,719 --> 00:02:44,318
+where everyone was working in their own
+
+81
+00:02:42,80 --> 00:02:45,920
+silo on basically the same attack and
+
+82
+00:02:44,318 --> 00:02:47,759
+and doing reverse engineering of the
+
+83
+00:02:45,919 --> 00:02:50,0
+165.92 --> 170
+same attacks without
+
+84
+00:02:47,759 --> 00:02:53,439
+having the ways, the means or the processes
+
+86
+00:02:51,120 --> 00:02:55,39
+to directly share with our peers so we
+
+87
+00:02:53,439 --> 00:02:55,919
+ended up with a lot of duplication of
+
+88
+00:02:55,39 --> 00:02:57,759
+work which ended
+
+89
+00:02:55,919 --> 00:02:59,199
+which was obviously frustrating from uh
+
+90
+00:02:57,759 --> 00:03:01,439
+for many of us
+
+91
+00:02:59,199 --> 00:03:03,598
+so Christophe Vandeplas at the time he
+
+92
+00:03:01,439 --> 00:03:06,318
+was working at the belgian
+
+93
+00:03:03,598 --> 00:03:08,399  
+ministry of defense um in his free time
+
+94
+00:03:06,318 --> 00:03:10,318
+wrote a platform called {inaudible}
+
+95
+00:03:08,400 --> 00:03:11,519
+that later on ended up becoming MISP so
+
+96
+00:03:10,318 --> 00:03:13,280
+the initial idea was
+
+97
+00:03:11,519 --> 00:03:14,800
+really for reverse engineers to share
+
+98
+00:03:13,280 --> 00:03:15,439
+the output of their work directly with
+
+99
+00:03:14,800 --> 00:03:18,719
+their peers
+
+100
+00:03:15,439 --> 00:03:22,158
+in a hosted platform and since then
+
+101
+00:03:18,719 --> 00:03:24,158
+obviously MISP has evolved and changed
+
+102
+00:03:22,158 --> 00:03:25,840
+the scope of what we were nowadays doing
+
+103
+00:03:24,158 --> 00:03:26,798
+with MISP and what sort of information
+
+104
+00:03:25,840 --> 00:03:28,640
+we're sharing
+
+105
+00:03:26,799 --> 00:03:30,159
+but it all started with this and since
+
+106
+00:03:28,639 --> 00:03:30,878
+then it has been an ongoing effort
+
+107
+00:03:30,158 --> 00:03:33,199
+basically by
+
+108
+00:03:30,878 --> 00:03:35,199
+a large community of different
+
+109
+00:03:33,199 --> 00:03:37,359
+requirements and different needs
+
+110
+00:03:35,199 --> 00:03:39,359
+and that has been building both the
+
+111
+00:03:37,360 --> 00:03:42,159
+ideas that go into MISP as well as the
+
+112
+00:03:39,360 --> 00:03:42,159
+software itself
+
+113
+00:03:43,919 --> 00:03:47,839
+next slide please
+
+114
+00:03:48,479 --> 00:03:51,919
+yeah so what is the background and why
+
+115
+00:03:51,199 --> 00:03:53,839
+we are doing
+
+116
+00:03:51,919 --> 00:03:56,79
+MISP it uh i think like Andras
+
+117
+00:03:53,840 --> 00:03:56,640
+mentioned it started from a with a kind
+
+118
+00:03:56,80 --> 00:03:59,40
+of
+
+119
+00:03:56,639 --> 00:04:00,479
+{inaudible} project for a small set of
+
+120
+00:03:59,39 --> 00:04:03,598
+CIRCL
+
+121
+00:04:00,479 --> 00:04:04,959
+CIRCL is nowadays
+
+122
+00:04:03,598 --> 00:04:07,359
+the CERT for the private sector, the
+
+123
+00:04:04,959 --> 00:04:08,959
+community {inaudible} in luxembourg
+
+124
+00:04:07,360 --> 00:04:11,200
+and we basically deal with the
+
+125
+00:04:08,959 --> 00:04:12,158
+development of MISP not only for our use
+
+126
+00:04:11,199 --> 00:04:15,359
+case but for many
+
+127
+00:04:12,158 --> 00:04:18,319
+different users so we are called as
+
+128
+00:04:15,360 --> 00:04:19,439
+a CERT we basically operate the
+
+129
+00:04:18,319 --> 00:04:22,478
+development and we operate
+
+130
+00:04:19,439 --> 00:04:22,478
+{inaudible} communities
+
+131
+00:04:23,600 --> 00:04:26,960
+so a little bit about our involvement
+
+132
+00:04:26,639 --> 00:04:28,478
+and
+
+133
+00:04:26,959 --> 00:04:30,79
+why we're doing this in the first place
+
+134
+00:04:28,478 --> 00:04:32,560
+so we as CIRCL we're funded by the
+
+135
+00:04:30,79 --> 00:04:35,680
+Ministry of Economy to basically build
+
+136
+00:04:32,560 --> 00:04:37,600
+security for the private sector uh and a
+
+137
+00:04:35,680 --> 00:04:39,199
+lot of what we do involves uh open
+
+138
+00:04:37,600 --> 00:04:39,840
+source software development so we're
+
+139
+00:04:39,199 --> 00:04:42,160
+basically
+
+140
+00:04:39,839 --> 00:04:44,79
+the funding that we get for the uh for
+
+141
+00:04:42,160 --> 00:04:45,199
+activities also cover our development
+
+142
+00:04:44,79 --> 00:04:47,918
+focus
+
+143
+00:04:45,199 --> 00:04:49,360
+we're also uh besides just building the
+
+144
+00:04:47,918 --> 00:04:50,159
+tools like {inaudible} mentioned we're
+
+145
+00:04:49,360 --> 00:04:52,479
+also
+
+146
+00:04:50,160 --> 00:04:53,919
+basically involved in a lot of sharing
+
+147
+00:04:52,478 --> 00:04:55,839
+activities as well as our day-to-day
+
+148
+00:04:53,918 --> 00:04:58,399
+operations we're users of the
+
+149
+00:04:55,839 --> 00:05:00,478
+tool primarily as well we basically host
+
+150
+00:04:58,399 --> 00:05:02,719
+a bunch of different communities for the
+
+151
+00:05:00,478 --> 00:05:05,439
+uh national C-Certs for the
+
+152
+00:05:02,720 --> 00:05:07,919
+luxembourgish private sector community
+
+153
+00:05:05,439 --> 00:05:09,680
+for law enforcement uh organizations
+
+154
+00:05:07,918 --> 00:05:10,959
+financial institutions and so on and so
+
+155
+00:05:09,680 --> 00:05:14,319
+forth
+
+156
+00:05:10,959 --> 00:05:16,239
+so so we're kind of uh
+
+157
+00:05:14,319 --> 00:05:18,240
+in the game on both sides so to say that
+
+158
+00:05:16,240 --> 00:05:21,120
+both as a
+
+159
+00:05:18,240 --> 00:05:22,0
+318.24 --> 322
+producer and as a consumer, also and the
+
+160
+00:05:21,120 --> 00:05:24,79
+project was
+
+161
+00:05:22,0 --> 00:05:25,759
+322 --> 325.759
+co-financed by the European Union
+
+162
+00:05:24,79 --> 00:05:29,120
+under the CEF project
+
+163
+00:05:25,759 --> 00:05:30,400
+uh so this is also one of the sources of
+
+164
+00:05:29,120 --> 00:05:33,120
+the income that we got basically to
+
+165
+00:05:30,399 --> 00:05:34,560
+build the tool and as a FIRST member you
+
+166
+00:05:33,120 --> 00:05:36,79
+have access to a MISP instance that is
+
+167
+00:05:34,560 --> 00:05:38,478
+operated and
+
+168
+00:05:36,79 --> 00:05:40,0
+336.08 --> 340
+co-maintained by FIRST and CIRCL that
+
+169
+00:05:38,478 --> 00:05:41,680
+you can get access to
+
+170
+00:05:40,0 --> 00:05:43,519
+340 --> 343.52
+so you just need to to use your
+
+171
+00:05:41,680 --> 00:05:45,680
+traditional credential or
+
+172
+00:05:43,519 --> 00:05:47,359
+access at first and you get access to
+
+173
+00:05:45,680 --> 00:05:49,600
+this instance with information
+
+174
+00:05:47,360 --> 00:05:51,439
+that you can use and so on we will talk
+
+175
+00:05:49,600 --> 00:05:54,160
+about that later on
+
+176
+00:05:51,439 --> 00:05:55,600
+so the main question and i think it's
+
+177
+00:05:54,160 --> 00:05:58,80
+coming from this story uh
+
+178
+00:05:55,600 --> 00:05:59,600
+as Andras mentioned from the early days
+
+179
+00:05:58,79 --> 00:06:01,758
+MISP was
+
+180
+00:05:59,600 --> 00:06:03,840
+focusing from a very specific aspect
+
+181
+00:06:01,759 --> 00:06:07,120
+which was malware reversing and so on
+
+182
+00:06:03,839 --> 00:06:08,799
+nowadays it's a threat intelligence sharing platforms we
+
+183
+00:06:07,120 --> 00:06:11,38
+are basically sharing any kind of
+
+184
+00:06:08,800 --> 00:06:13,38
+intelligence through uh through MISP
+
+185
+00:06:11,38 --> 00:06:14,478
+um because we had an evolution of the
+
+186
+00:06:13,38 --> 00:06:16,399
+time for the different things so
+
+187
+00:06:14,478 --> 00:06:18,879
+and our main goals and that's very
+
+188
+00:06:16,399 --> 00:06:21,439
+important for us it's an open source
+
+189
+00:06:18,879 --> 00:06:23,120
+software so that means MISP will always
+
+190
+00:06:21,439 --> 00:06:23,519
+remain an open source project we even
+
+191
+00:06:23,120 --> 00:06:26,0
+383.12 --> 386
+take
+
+192
+00:06:23,519 --> 00:06:26,879
+some decisions within the project to
+
+193
+00:06:26,0 --> 00:06:29,120
+386 --> 389.12
+keep it as
+
+194
+00:06:26,879 --> 00:06:30,639
+open source and that's that's really a
+
+195
+00:06:29,120 --> 00:06:32,720
+key for us so it's really uh
+
+196
+00:06:30,639 --> 00:06:34,800
+something that you can download yourself
+
+197
+00:06:32,720 --> 00:06:37,39
+run on your infrastructure and so on
+
+198
+00:06:34,800 --> 00:06:38,240
+you can really have the full control on
+
+199
+00:06:37,38 --> 00:06:40,639
+the software stack
+
+200
+00:06:38,240 --> 00:06:42,0
+398.24 --> 402
+when you are using MISP and one of the
+
+201
+00:06:40,639 --> 00:06:43,38
+goals of the software itself is to
+
+202
+00:06:42,0 --> 00:06:46,240
+402 --> 406.24
+collect information
+
+203
+00:06:43,38 --> 00:06:48,159
+from other partners, from in the {inaudible}
+
+204
+00:06:46,240 --> 00:06:49,280
+from automatic tools from different
+
+205
+00:06:48,160 --> 00:06:50,800
+fields and so on
+
+206
+00:06:49,279 --> 00:06:53,198
+that was really one of the initial goal
+
+207
+00:06:50,800 --> 00:06:55,680
+of MISP is like being able to collect
+
+208
+00:06:53,199 --> 00:06:57,360
+to get all this information into
+
+209
+00:06:55,680 --> 00:06:59,38
+one place
+
+210
+00:06:57,360 --> 00:07:00,560
+and then afterwards what you can do with
+
+211
+00:06:59,38 --> 00:07:02,719
+it is to normalize
+
+212
+00:07:00,560 --> 00:07:03,839
+correlate this information, extend the
+
+213
+00:07:02,720 --> 00:07:06,560
+information and enrich
+
+214
+00:07:03,839 --> 00:07:08,879
+information with more information and then
+
+216
+00:07:07,199 --> 00:07:10,800
+really benefit from the sharing aspect
+
+217
+00:07:08,879 --> 00:07:13,120
+of MISP and you can allow
+
+218
+00:07:10,800 --> 00:07:13,840
+teams and community to collaborate
+
+219
+00:07:13,120 --> 00:07:16,478
+and we have
+
+220
+00:07:13,839 --> 00:07:18,318
+seen MISP for example use not only
+
+221
+00:07:16,478 --> 00:07:20,159
+within different organizations but even
+
+222
+00:07:18,319 --> 00:07:21,759
+within a single organization you can, for
+
+223
+00:07:20,160 --> 00:07:24,240
+example run multiple MISP
+
+224
+00:07:21,759 --> 00:07:25,120
+to collaborate directly on different
+
+225
+00:07:24,240 --> 00:07:28,79
+investigations
+
+226
+00:07:25,120 --> 00:07:29,519
+incidents and cases and obviously when
+
+227
+00:07:28,79 --> 00:07:31,279
+you have all this information and all
+
+228
+00:07:29,519 --> 00:07:33,758
+these analytic platform into MISP
+
+229
+00:07:31,279 --> 00:07:34,638
+you are ready to use this information to
+
+230
+00:07:33,759 --> 00:07:36,960
+for example
+
+231
+00:07:34,639 --> 00:07:39,840
+feed your automatic protective tools
+
+232
+00:07:36,959 --> 00:07:42,0
+456.96 --> 462
+like intrusion detection systems,
+
+233
+00:07:39,839 --> 00:07:43,279
+firewalls whatever and to feed
+
+234
+00:07:42,0 --> 00:07:45,598
+462 --> 465.599
+automatically those
+
+235
+00:07:43,279 --> 00:07:46,799
+information to basically make protective
+
+236
+00:07:45,598 --> 00:07:50,319
+measures
+
+237
+00:07:46,800 --> 00:07:50,319
+in your environment
+
+238
+00:07:51,199 --> 00:07:55,840
+so, start from the starting point that we
+
+239
+00:07:54,478 --> 00:07:57,680
+already mentioned basically how we
+
+240
+00:07:55,839 --> 00:08:00,638
+started out with MISP
+
+241
+00:07:57,680 --> 00:08:02,800
+let's have a quick look at how uh the
+
+242
+00:08:00,639 --> 00:08:04,400
+user base of MISP evolved in terms of
+
+243
+00:08:02,800 --> 00:08:06,0
+482.8 --> 486
+the different types of stakeholders
+
+244
+00:08:04,399 --> 00:08:08,560
+within our own organizations and other organizations
+
+246
+00:08:07,120 --> 00:08:10,319
+the reason for that is obviously that
+
+247
+00:08:08,560 --> 00:08:12,560
+this drives the development process as well
+
+249
+00:08:10,800 --> 00:08:14,400
+so the way MISP grows over time really
+
+250
+00:08:12,560 --> 00:08:14,800
+depends on the type of users that are using
+
+252
+00:08:16,478 --> 00:08:18,319
+the type of users that are requesting new
+
+253
+00:08:16,478 --> 00:08:20,159
+features or that are providing pull
+
+254
+00:08:18,319 --> 00:08:22,639
+requests on the project and providing code
+
+256
+00:08:20,720 --> 00:08:23,759
+for the project so i said before
+
+257
+00:08:22,639 --> 00:08:26,160
+initially
+
+258
+00:08:23,759 --> 00:08:27,759
+the scope of MISP was very limited it
+
+259
+00:08:26,160 --> 00:08:29,360
+was basically just the output of malware
+
+260
+00:08:27,759 --> 00:08:31,199
+reversers which meant
+
+261
+00:08:29,360 --> 00:08:32,479
+raw indicators that we were extracting
+
+262
+00:08:31,199 --> 00:08:34,560
+during the process and that we're
+
+263
+00:08:32,479 --> 00:08:36,639
+sharing directly
+
+264
+00:08:34,559 --> 00:08:38,79
+with our partners, this meant very little
+
+265
+00:08:36,639 --> 00:08:39,519
+analysis was done on each of these
+
+266
+00:08:38,80 --> 00:08:41,599
+individual indicators there was very
+
+267
+00:08:39,519 --> 00:08:43,440
+little information in terms of
+
+268
+00:08:41,599 --> 00:08:45,200
+of why those data points are relevant in
+
+269
+00:08:43,440 --> 00:08:47,360
+the long term how they are meant to be used
+
+271
+00:08:45,759 --> 00:08:49,519
+from detection perspective they were
+
+272
+00:08:47,360 --> 00:08:52,480
+really just the raw output
+
+273
+00:08:49,519 --> 00:08:54,0
+529.519 --> 534
+from the analysis process or the
+
+274
+00:08:52,480 --> 00:08:56,80
+reversing process
+
+275
+00:08:54,0 --> 00:08:57,519
+534 --> 537.519
+now one of the side effects of this when
+
+276
+00:08:56,80 --> 00:08:59,440
+you start building a collection within
+
+277
+00:08:57,519 --> 00:09:01,360
+your organization of this information
+
+278
+00:08:59,440 --> 00:09:02,880
+the security analysts are feeding your
+
+279
+00:09:01,360 --> 00:09:04,320
+various protective tools become
+
+280
+00:09:02,879 --> 00:09:05,838
+interested in that data set
+
+281
+00:09:04,320 --> 00:09:08,0
+544.32 --> 548
+because obviously whatever is targeting
+
+282
+00:09:05,839 --> 00:09:10,160
+your organization or your direct peers
+
+283
+00:09:08,0 --> 00:09:11,360
+548 --> 551.36
+are probably the most relevant piece of
+
+284
+00:09:10,159 --> 00:09:13,39
+information that you can use for
+
+285
+00:09:11,360 --> 00:09:16,159
+detection
+
+286
+00:09:13,39 --> 00:09:19,39
+so one of the first steps that we opened
+
+288
+00:09:16,958 --> 00:09:20,479
+up to was basically involving our own
+
+289
+00:09:19,39 --> 00:09:23,278
+security analyst with our
+
+290
+00:09:20,480 --> 00:09:24,320
+own organizations so they can hook
+
+291
+00:09:23,278 --> 00:09:27,360
+the output of
+
+292
+00:09:24,320 --> 00:09:30,80
+of the reverse engineering team
+
+293
+00:09:27,360 --> 00:09:31,360
+up to their SIEMs to their IDSs to
+
+294
+00:09:30,80 --> 00:09:33,360
+their firewalls
+
+295
+00:09:31,360 --> 00:09:35,440
+and to feed this data directly into
+
+296
+00:09:33,360 --> 00:09:36,720
+their protective measures
+
+297
+00:09:35,440 --> 00:09:38,720
+now one of the interesting things when
+
+298
+00:09:36,720 --> 00:09:40,800
+you start doing that though is that you
+
+299
+00:09:38,720 --> 00:09:42,560
+generate a new type of output which is
+
+300
+00:09:40,799 --> 00:09:44,559
+timeliness for the data, freshness for
+
+301
+00:09:42,559 --> 00:09:45,838
+the data as well as feedback on how
+
+302
+00:09:44,559 --> 00:09:47,838
+useful the data was
+
+303
+00:09:45,839 --> 00:09:50,240
+so we're very often when you're
+
+304
+00:09:47,839 --> 00:09:53,40
+extracting information
+
+305
+00:09:50,240 --> 00:09:55,360
+by sandboxing for example a lot of the
+
+306
+00:09:53,39 --> 00:09:57,679
+data generated will be noise in the end
+
+307
+00:09:55,360 --> 00:09:59,759
+and this noise will generate false
+
+308
+00:09:57,679 --> 00:10:02,159
+positive alerts for example
+
+309
+00:09:59,759 --> 00:10:04,319
+in your detection tools. Now feeding this
+
+310
+00:10:02,159 --> 00:10:06,559
+information back
+
+311
+00:10:04,320 --> 00:10:10,559
+to data gave it a whole new type of value
+
+313
+00:10:07,519 --> 00:10:12,159
+we had freshness so if an older
+
+314
+00:10:10,559 --> 00:10:14,159
+indicator was reused
+
+315
+00:10:12,159 --> 00:10:15,439
+over time we saw that that is still
+
+316
+00:10:14,159 --> 00:10:18,160
+something that is actively to be monitored
+
+318
+00:10:16,559 --> 00:10:19,838
+and if we saw that something turned out
+
+319
+00:10:18,159 --> 00:10:21,199
+to be a cleaned up host
+
+320
+00:10:19,839 --> 00:10:23,440
+in the meanwhile or something was a
+
+321
+00:10:21,200 --> 00:10:25,200
+false positive from the get-go
+
+322
+00:10:23,440 --> 00:10:28,399
+we could feed that information back as well
+
+324
+00:10:27,399 --> 00:10:31,759
+so suddenly once you have timeliness as
+
+325
+00:10:28,399 --> 00:10:33,759
+well as the the raw data itself
+
+326
+00:10:31,759 --> 00:10:35,278
+you get the intelligence analyst
+
+327
+00:10:33,759 --> 00:10:36,399
+interested that are tracking the
+
+328
+00:10:35,278 --> 00:10:42,0
+movements and the changes of how attackers operate
+
+330
+00:10:39,519 --> 00:10:42,639
+uh over time so that means that usually
+
+332
+00:10:45,360 --> 00:10:47,199
+back then especially in 2012 in most of our
+
+333
+00:10:45,360 --> 00:10:48,560
+organizations the people that are doing
+
+334
+00:10:47,200 --> 00:10:50,560
+intelligence and the people that were
+
+335
+00:10:48,559 --> 00:10:52,239
+doing operations and security for the
+
+336
+00:10:50,559 --> 00:10:55,680
+operations were usually working in their own silos
+
+338
+00:10:53,440 --> 00:10:57,40
+so while there was obviously interaction
+
+339
+00:10:55,679 --> 00:10:58,958
+between the teams, it was not as
+
+340
+00:10:57,39 --> 00:11:01,919
+ingrained to work together
+
+341
+00:10:58,958 --> 00:11:03,599
+between those type of roles but this
+
+342
+00:11:01,919 --> 00:11:04,0
+661.92 --> 664
+changed over time and one of the changes
+
+344
+00:11:04,0 --> 00:11:08,78
+664 --> 668.079
+that we saw happened was that the output
+
+345
+00:11:06,240 --> 00:11:10,240
+of what the security analysts
+
+346
+00:11:08,78 --> 00:11:12,159
+and the reversers and the analysts were
+
+347
+00:11:10,240 --> 00:11:14,480
+outputting basically from the operation side
+
+349
+00:11:12,879 --> 00:11:16,399
+became more and more interesting for the
+
+350
+00:11:14,480 --> 00:11:17,839
+intelligence analysts that meant that
+
+351
+00:11:16,399 --> 00:11:19,919
+if they were tracking a certain threat
+
+352
+00:11:17,839 --> 00:11:21,600
+actor and they could attribute certain
+
+353
+00:11:19,919 --> 00:11:23,439
+actions that they were seen in the
+
+354
+00:11:21,600 --> 00:11:25,519
+network of the organization
+
+355
+00:11:23,440 --> 00:11:26,959
+to the certain threat actor they could
+
+356
+00:11:25,519 --> 00:11:29,278
+monitor for example how
+
+357
+00:11:26,958 --> 00:11:30,879
+the given actor was changing how fast
+
+358
+00:11:29,278 --> 00:11:32,78
+they were changing infrastructure
+
+359
+00:11:30,879 --> 00:11:34,0
+690.88 --> 694
+whether they were switching up their
+
+360
+00:11:32,78 --> 00:11:36,78
+methodology and this
+
+361
+00:11:34,0 --> 00:11:37,519
+694 --> 697.519
+gave them a lot of idea of useful data
+
+362
+00:11:36,78 --> 00:11:39,199
+of improving their libraries of the
+
+363
+00:11:37,519 --> 00:11:40,799
+threat actors that they were tracking
+
+364
+00:11:39,200 --> 00:11:41,920
+so suddenly we got this group interests
+
+365
+00:11:40,799 --> 00:11:43,838
+as well and they were obviously
+
+366
+00:11:41,919 --> 00:11:44,879
+producing data as well so nowadays if
+
+367
+00:11:43,839 --> 00:11:47,279
+you look at MISP
+
+368
+00:11:44,879 --> 00:11:49,200
+going from a raw indicator sharing platform
+
+369
+00:11:47,278 --> 00:11:50,399
+that MISP was initially
+
+370
+00:11:49,200 --> 00:11:52,160
+nowadays you have a lot of the high
+
+371
+00:11:50,399 --> 00:11:53,759
+level threat intel information included
+
+372
+00:11:52,159 --> 00:11:56,720
+with the data as well so you will see threat reports
+
+374
+00:11:54,879 --> 00:11:58,720
+you will see interconnected information
+
+375
+00:11:56,720 --> 00:12:04,399
+about threat actors modus operandi
+
+377
+00:12:01,839 --> 00:12:06,79
+infrastructure impact and so on so forth
+
+378
+00:12:04,399 --> 00:12:07,360
+these extra layers of information that
+
+379
+00:12:06,78 --> 00:12:08,719
+we were missing initially
+
+380
+00:12:07,360 --> 00:12:10,0
+727.36 --> 730
+so this was the biggest change that we
+
+381
+00:12:08,720 --> 00:12:11,440
+had over time within our own
+
+382
+00:12:10,0 --> 00:12:13,919
+730 --> 733.92
+organizations but
+
+383
+00:12:11,440 --> 00:12:15,519
+obviously as a CSIRT that has
+
+384
+00:12:13,919 --> 00:12:17,199
+different constituencies
+
+385
+00:12:15,519 --> 00:12:18,799
+we're also interacting with the security
+
+386
+00:12:17,200 --> 00:12:20,720
+teams of other organizations and one of
+
+387
+00:12:18,799 --> 00:12:22,319
+the things we noticed early on was
+
+388
+00:12:20,720 --> 00:12:24,160
+there's a lot of the issues that other
+
+389
+00:12:22,320 --> 00:12:25,600
+types of organizations had internally
+
+390
+00:12:24,159 --> 00:12:28,800
+with information sharing are very similar to ours
+
+392
+00:12:26,879 --> 00:12:30,958
+so initially the first use case that we
+
+393
+00:12:28,799 --> 00:12:32,799
+got that was different and from our
+
+394
+00:12:30,958 --> 00:12:36,719
+normal security use case
+
+395
+00:12:32,799 --> 00:12:38,399
+was basically the various financial
+
+396
+00:12:36,720 --> 00:12:39,920
+organizations reaching out to us saying
+
+397
+00:12:38,399 --> 00:12:41,759
+that their fraud teams were
+
+398
+00:12:39,919 --> 00:12:43,599
+running into similar sort of issues with
+
+399
+00:12:41,759 --> 00:12:45,759
+sharing between their teams,
+
+400
+00:12:43,600 --> 00:12:47,839
+sharing with other partner teams,
+
+401
+00:12:45,759 --> 00:12:50,319
+information about mule accounts and
+
+402
+00:12:47,839 --> 00:12:51,519
+about other fraud related information
+
+403
+00:12:50,320 --> 00:12:53,680
+so they reached out to us and
+
+404
+00:12:51,519 --> 00:12:54,480
+basically their security teams reached
+
+405
+00:12:53,679 --> 00:12:57,199
+out to us and said
+
+406
+00:12:54,480 --> 00:12:58,639
+can't we just try to help them also
+
+407
+00:12:57,200 --> 00:13:00,0
+777.2 --> 780
+to share that sort of information
+
+408
+00:12:58,639 --> 00:13:01,759
+through MISP directly, I mean we already
+
+409
+00:13:00,0 --> 00:13:03,200
+780 --> 783.2
+had the tooling in place
+
+410
+00:13:01,759 --> 00:13:05,200
+it was just a question of changing the data model
+
+412
+00:13:05,200 --> 00:13:08,639
+so we we started doing that for uh together
+
+413
+00:13:07,120 --> 00:13:10,480
+with the financial sector initially
+
+414
+00:13:08,639 --> 00:13:12,0
+788.639 --> 792
+where we expanded the data model of MISP
+
+415
+00:13:10,480 --> 00:13:13,519
+when we allowed for modeling of new
+
+416
+00:13:12,0 --> 00:13:15,919
+792 --> 795.92
+custom data types
+
+417
+00:13:13,519 --> 00:13:17,679
+and it's even surprising to us at the
+
+418
+00:13:15,919 --> 00:13:20,319
+time turned into a success
+
+419
+00:13:17,679 --> 00:13:21,599
+very rapidly so nowadays we're involved
+
+420
+00:13:20,320 --> 00:13:22,959
+with quite a few different types of
+
+421
+00:13:21,600 --> 00:13:25,519
+organizations out there
+
+422
+00:13:22,958 --> 00:13:26,879
+replicating the same scenario where for
+
+423
+00:13:25,519 --> 00:13:30,320
+example law enforcement, where we initially had
+
+425
+00:13:28,320 --> 00:13:32,79
+mostly contact with their security teams
+
+426
+00:13:30,320 --> 00:13:36,240
+and helping them build data sets for bootstrapping their forensic
+
+429
+00:13:34,399 --> 00:13:38,480
+investigations nowadays we have all
+
+430
+00:13:36,240 --> 00:13:40,959
+sorts of information sharing involving
+
+431
+00:13:38,480 --> 00:13:45,278
+uh for example uh seized goods information sharing from
+
+433
+00:13:42,639 --> 00:13:48,799
+border control agencies uh law enforcement agencies
+
+435
+00:13:46,879 --> 00:13:51,120
+sharing information about passenger information
+
+436
+00:13:48,799 --> 00:13:53,359
+so a lot of the type of data
+
+437
+00:13:51,120 --> 00:13:55,360
+sharing that was very unusual for us as
+
+438
+00:13:53,360 --> 00:13:58,79
+a CSIRT initially
+
+439
+00:13:55,360 --> 00:13:58,879
+now once you get all this data in a
+
+440
+00:13:58,78 --> 00:14:01,39
+system and you
+
+441
+00:13:58,879 --> 00:14:04,399
+started building a data set from your community
+
+443
+00:14:02,480 --> 00:14:06,79
+you start to see trends in the data set
+
+444
+00:14:04,399 --> 00:14:07,839
+and this is what gets
+
+445
+00:14:06,78 --> 00:14:09,759
+for example our risk analysis team
+
+446
+00:14:07,839 --> 00:14:11,440
+interested in it the moment that you're
+
+447
+00:14:09,759 --> 00:14:12,639
+seeing how attackers are changing their
+
+448
+00:14:11,440 --> 00:14:15,199
+trends over time
+
+449
+00:14:12,639 --> 00:14:18,719
+you can better advise your constituency your customers and so on
+
+451
+00:14:17,360 --> 00:14:22,160
+about the different risks that they might be facing and the
+
+453
+00:14:20,958 --> 00:14:24,879
+different risks that they should be preparing for
+
+455
+00:14:23,278 --> 00:14:26,958
+and preparing the organizations for
+
+456
+00:14:24,879 --> 00:14:29,519
+based on what the same sector is facing
+
+457
+00:14:26,958 --> 00:14:31,359
+perhaps in the same geographic location
+
+458
+00:14:29,519 --> 00:14:33,120
+so suddenly you get a lot of knowledge
+
+459
+00:14:31,360 --> 00:14:35,120
+out of the collected data as long as
+
+460
+00:14:33,120 --> 00:14:36,720
+data is well contextualized and i think
+
+461
+00:14:35,120 --> 00:14:38,78
+this will be one of the main topics that
+
+462
+00:14:36,720 --> 00:14:41,519
+we're going to be talking about quite a bit today and tomorrow
+
+464
+00:14:39,679 --> 00:14:43,599
+is contextualizing the information and
+
+465
+00:14:41,519 --> 00:14:47,600
+making the information actually usable
+
+466
+00:14:43,600 --> 00:14:47,600
+and turning data really into knowledge
+
+467
+00:14:49,600 --> 00:14:55,40
+yeah so like Andras mentioned
+
+468
+00:14:52,639 --> 00:14:56,240
+we have a pretty large set of different
+
+469
+00:14:55,39 --> 00:15:00,0
+895.04 --> 900
+communities using MISP
+
+470
+00:14:56,240 --> 00:15:02,159
+and over the time it became i think more
+
+471
+00:15:00,0 --> 00:15:03,759
+900 --> 903.76
+complicated to handle all those requests
+
+472
+00:15:02,159 --> 00:15:07,120
+from different organizations
+
+473
+00:15:03,759 --> 00:15:10,0
+903.76 --> 910
+um so we came with a model of governance
+
+474
+00:15:07,120 --> 00:15:12,240
+even if it's a very lightweight one we
+
+475
+00:15:10,0 --> 00:15:13,839
+910 --> 913.839
+decided to have this kind of models to
+
+476
+00:15:12,240 --> 00:15:15,680
+still benefit from the open source
+
+477
+00:15:13,839 --> 00:15:17,199
+community model and then
+
+478
+00:15:15,679 --> 00:15:19,278
+bring all the experience from a
+
+479
+00:15:17,198 --> 00:15:21,198
+different community into systems where
+
+480
+00:15:19,278 --> 00:15:22,720
+it allows us to develop and extend the
+
+481
+00:15:21,198 --> 00:15:24,958
+software so we decided to
+
+482
+00:15:22,720 --> 00:15:26,240
+create this kind of models where we
+
+483
+00:15:24,958 --> 00:15:28,879
+basically
+
+484
+00:15:26,240 --> 00:15:30,320
+take care of all the features and
+
+485
+00:15:28,879 --> 00:15:33,679
+requests that we receive from different organizations
+
+487
+00:15:31,679 --> 00:15:36,599
+so we use this kind of priority list of different features
+
+489
+00:15:35,600 --> 00:15:38,720
+and we get that feedback from {inaudible}
+
+491
+00:15:38,720 --> 00:15:42,879
+one of the {inaudible} one i would say is
+
+492
+00:15:40,639 --> 00:15:44,480
+Github so we get the feed from
+
+493
+00:15:42,879 --> 00:15:46,399
+the different issue that we receive from
+
+494
+00:15:44,480 --> 00:15:48,639
+Github i mean on the if you look at on
+
+495
+00:15:46,399 --> 00:15:50,320
+Github you'll see that we have a
+
+496
+00:15:48,639 --> 00:15:52,320
+significant number of issues and those
+
+497
+00:15:50,320 --> 00:15:54,800
+issue are usually for us a way to track down
+
+499
+00:15:52,799 --> 00:15:56,879
+all the different requests of features
+
+500
+00:15:54,639 --> 00:15:59,120
+in MISP and that's one way to get it.
+
+501
+00:15:56,879 --> 00:16:02,639
+Another way and this one is a quite a common one
+
+503
+00:16:00,639 --> 00:16:05,39
+is basically a training or session like
+
+504
+00:16:02,399 --> 00:16:06,799
+this where people are providing feedback,
+
+505
+00:16:05,39 --> 00:16:09,39
+bug reports, future requests and so on
+
+506
+00:16:06,799 --> 00:16:10,879
+directly during the training and for us
+
+507
+00:16:09,39 --> 00:16:12,958
+uh i think really practical and we can
+
+508
+00:16:10,879 --> 00:16:15,39
+get all this information needed for us
+
+509
+00:16:12,958 --> 00:16:16,0
+972.959 --> 976
+to improve the software. Another thing
+
+510
+00:16:15,39 --> 00:16:17,759
+that we do and
+
+511
+00:16:16,0 --> 00:16:19,839
+976 --> 979.839
+that's maybe for the audience some
+
+512
+00:16:17,759 --> 00:16:21,39
+people are interested in that one
+
+513
+00:16:19,839 --> 00:16:22,560
+we know that there are plenty of
+
+514
+00:16:21,39 --> 00:16:24,399
+different MISP of groups that we don't
+
+515
+00:16:22,559 --> 00:16:28,319
+control and that we don't manage that's
+
+516
+00:16:24,399 --> 00:16:29,679
+great we have for example ISACs, ISAO
+
+517
+00:16:28,320 --> 00:16:31,360
+doing really those kind of things where
+
+518
+00:16:29,679 --> 00:16:33,838
+you have those kind of user groups
+
+519
+00:16:31,360 --> 00:16:35,600
+and what we do we participate on a
+
+520
+00:16:33,839 --> 00:16:37,279
+regular basis to one of those groups for
+
+521
+00:16:35,600 --> 00:16:39,0
+995.6 --> 998
+example on a quarterly basis on a yearly basis
+
+523
+00:16:38,0 --> 00:16:41,759
+998 --> 1001.759
+and we do a collection of requirements
+
+524
+00:16:40,240 --> 00:16:44,240
+from those different groups
+
+525
+00:16:41,759 --> 00:16:46,720
+during one session and that's really
+
+527
+00:16:44,958 --> 00:16:48,799
+i think useful for us because it's a way
+
+528
+00:16:46,720 --> 00:16:50,720
+to to gather information so for example
+
+529
+00:16:48,799 --> 00:16:52,78
+Andras mentioned those
+
+530
+00:16:50,720 --> 00:16:53,519
+financial groups where people are
+
+531
+00:16:52,78 --> 00:16:54,559
+sharing information about bank account
+
+532
+00:16:53,519 --> 00:16:56,480
+detail and so on
+
+533
+00:16:54,559 --> 00:16:57,919
+and that's where we basically gather all
+
+534
+00:16:56,480 --> 00:16:59,278
+those requirements
+
+535
+00:16:57,919 --> 00:17:01,39
+so if you are setting up a group
+
+536
+00:16:59,278 --> 00:17:03,278
+somewhere in US or
+
+537
+00:17:01,39 --> 00:17:04,318
+in the world about sharing information
+
+538
+00:17:03,278 --> 00:17:06,0
+1023.279 --> 1026
+and so on and you want to
+
+539
+00:17:04,318 --> 00:17:07,759
+invite us at some point in time it's a
+
+540
+00:17:06,0 --> 00:17:12,160
+1026 --> 1028.959
+way for us to gather those kind of requirements
+
+542
+00:17:08,959 --> 00:17:13,759
+we do a summit which is a yearly event
+
+543
+00:17:12,160 --> 00:17:15,600
+usually it was physical but nowadays
+
+544
+00:17:13,759 --> 00:17:18,0
+1033.76 --> 1038
+it's virtual trainings
+
+545
+00:17:15,599 --> 00:17:19,918
+so it's basically every user or
+
+546
+00:17:18,0 --> 00:17:21,199
+1038 --> 1041.199
+organizations using MISP presenting what
+
+547
+00:17:19,919 --> 00:17:22,959
+they are doing
+
+548
+00:17:21,199 --> 00:17:24,558
+it's a way for us to to see the
+
+549
+00:17:22,959 --> 00:17:26,480
+interactions and see what
+
+550
+00:17:24,558 --> 00:17:28,480
+can be improved in MISP and see {inaudible}
+
+551
+00:17:26,480 --> 00:17:29,759
+in the community behind
+
+552
+00:17:28,480 --> 00:17:31,839
+and then we have a kind of 20%
+
+553
+00:17:29,759 --> 00:17:35,200
+project around in MISP
+
+554
+00:17:31,839 --> 00:17:38,558
+1051.84 --> 1056
+where we design new functionalities and we test
+
+556
+00:17:36,0 --> 00:17:39,919
+1056 --> 1059.919
+them out for example one of those is the
+
+557
+00:17:38,558 --> 00:17:41,200
+detailing of indicators
+
+558
+00:17:39,919 --> 00:17:42,400
+which was a request from different
+
+559
+00:17:41,200 --> 00:17:43,919
+organizations but it was kind of
+
+560
+00:17:42,400 --> 00:17:45,919
+difficult to design
+
+561
+00:17:43,919 --> 00:17:48,240
+and with this kind of models where we
+
+562
+00:17:45,919 --> 00:17:50,480
+designed first as a kind of prototype
+
+563
+00:17:48,240 --> 00:17:52,558
+multiple iterations uh we did a multiple
+
+564
+00:17:50,480 --> 00:17:56,0
+1070.48 --> 1076
+research paper on that and then finally
+
+565
+00:17:52,558 --> 00:17:57,918
+this become part of the MISP core software
+
+566
+00:17:56,0 --> 00:17:59,679
+1076 --> 1079.679
+we will show that later on but so we
+
+567
+00:17:57,919 --> 00:18:01,679
+have a lightweight governance model
+
+568
+00:17:59,679 --> 00:18:03,840
+but really the goal is to gather as
+
+569
+00:18:01,679 --> 00:18:05,280
+much feedback from the user so don't
+
+570
+00:18:03,839 --> 00:18:08,599
+hesitate if you have any bug reports, ideas and so on
+
+571
+00:18:05,279 --> 00:18:09,319
+either open an issue,
+
+573
+00:18:08,319 --> 00:18:11,918
+get in touch with us.
+
+575
+00:18:11,919 --> 00:18:16,400
+You are more than welcome to basically
+
+576
+00:18:13,279 --> 00:18:16,399
+share such kind of information.
+
+577
+00:18:17,119 --> 00:18:22,719
+Yeah, now addressing the elephant in the room
+
+579
+00:18:20,720 --> 00:18:24,160
+when you bring so many different
+
+580
+00:18:22,160 --> 00:18:25,759
+organizations together and build a large
+
+581
+00:18:24,160 --> 00:18:27,200
+community of sharing with different
+
+582
+00:18:25,759 --> 00:18:28,558
+needs and requirements
+
+583
+00:18:27,200 --> 00:18:31,200
+you're obviously going to have to run
+
+584
+00:18:28,558 --> 00:18:32,720
+into conflicting requirements as well
+
+585
+00:18:31,200 --> 00:18:34,240
+so one of the most obvious ones that
+
+586
+00:18:32,720 --> 00:18:36,640
+that we're dealing with very often with
+
+587
+00:18:34,240 --> 00:18:38,720
+information sharing and something that
+
+588
+00:18:36,640 --> 00:18:39,840
+that we're working on tackling ,
+
+590
+00:18:38,839 --> 00:18:43,599
+basically since we started with MISP, is dealing
+
+591
+00:18:42,79 --> 00:18:45,279
+with a different requirement of
+
+592
+00:18:43,599 --> 00:18:46,879
+of what you count as valuable
+
+593
+00:18:45,279 --> 00:18:47,519
+information depending on your use case
+
+594
+00:18:46,880 --> 00:18:51,599
+so this is different also within 
+
+596
+00:18:50,400 --> 00:18:53,360
+different analysts, different roles
+
+597
+00:18:51,599 --> 00:18:56,79
+within the same organization as
+
+598
+00:18:53,359 --> 00:18:58,720
+well so for example, for us as a CSIRT in general
+
+600
+00:18:57,38 --> 00:19:00,240
+uh detection is the most important
+
+601
+00:18:58,720 --> 00:19:04,640
+matter so we're interested
+
+602
+00:19:00,240 --> 00:19:08,880
+in in using indicators to detect if our constituency
+
+604
+00:19:06,880 --> 00:19:10,0
+1146.88 --> 1150
+is affected by something that the
+
+605
+00:19:08,880 --> 00:19:12,880
+information is being
+
+606
+00:19:10,0 --> 00:19:14,160
+1150 --> 1154.16
+shared about or whether uh any of the
+
+607
+00:19:12,880 --> 00:19:17,200
+the infrastructure that we're
+
+608
+00:19:14,160 --> 00:19:17,840
+responsible for is infected 
+
+609
+00:19:17,200 --> 00:19:22,639
+on the other hand if you're talking to an isp
+
+611
+00:19:19,919 --> 00:19:22,640
+one of the large
+
+612
+00:19:22,720 --> 00:19:26,720
+requirements from an isp basically will
+
+613
+00:19:24,640 --> 00:19:29,38
+be able to protect their users
+
+614
+00:19:26,720 --> 00:19:30,79
+from potential harm so that means that
+
+616
+00:19:30,79 --> 00:19:34,480
+if there are any urls, websites, and so on
+
+618
+00:19:34,480 --> 00:19:38,480
+that they should block for their users they
+
+619
+00:19:36,880 --> 00:19:39,679
+need to be able to generate a block list
+
+620
+00:19:38,480 --> 00:19:41,440
+out of the data
+
+621
+00:19:39,679 --> 00:19:43,600
+that is considered to be malicious
+
+622
+00:19:41,440 --> 00:19:45,360
+enough now if you compare these two use cases
+
+623
+00:19:43,599 --> 00:19:48,240
+with each other detection versus blocking
+
+625
+00:19:46,240 --> 00:19:49,359
+you will immediately see that the effect
+
+627
+00:19:49,359 --> 00:19:53,359
+of having a false positive in the data
+
+628
+00:19:51,200 --> 00:19:56,160
+set or data that is no longer fresh
+
+629
+00:19:53,359 --> 00:19:57,119
+has a completely different impact 
+
+630
+00:19:56,160 --> 00:19:58,960
+sure for us when
+
+631
+00:19:57,119 --> 00:20:00,719
+that are mostly in the detection game
+
+632
+00:19:58,960 --> 00:20:02,400
+it's annoying we get a false positive
+
+633
+00:20:00,720 --> 00:20:04,400
+alert it has to be handled
+
+634
+00:20:02,400 --> 00:20:05,759
+and it takes time and effort it also
+
+635
+00:20:04,400 --> 00:20:07,200
+introduces something called alert fatigue
+
+636
+00:20:05,759 --> 00:20:09,319
+that i'm sure many of you are familiar with
+
+638
+00:20:08,319 --> 00:20:12,79
+if you're getting a lot of false
+
+639
+00:20:09,440 --> 00:20:15,120
+positive alerts you're more likely to ignore the
+
+641
+00:20:13,119 --> 00:20:16,798
+next alert that you get but besides that
+
+642
+00:20:15,679 --> 00:20:20,879
+it has no real operational impact on us 
+
+644
+00:20:19,119 --> 00:20:22,879
+on the other hand for an isp that ends up blocking
+
+645
+00:20:20,880 --> 00:20:24,880
+something that is uh
+
+646
+00:20:22,880 --> 00:20:27,400
+potentially a false positive might have a catastrophic impact
+
+648
+00:20:26,400 --> 00:20:33,600
+imagine if someone accidentally, for example shares
+
+650
+00:20:29,599 --> 00:20:35,759
+facebook.com as an indicator that might
+
+651
+00:20:33,279 --> 00:20:39,119
+basically cause a riot with their users or it might {inaudible}
+
+653
+00:20:37,279 --> 00:20:41,519
+but it's a different story
+
+654
+00:20:39,119 --> 00:20:44,479
+but with that in mind, you see that these
+
+655
+00:20:41,519 --> 00:20:47,679
+two use cases are already conflicting
+
+656
+00:20:44,480 --> 00:20:49,360
+now if you also take the perspective of
+
+657
+00:20:47,679 --> 00:20:52,400
+intelligence analysts that are tracking
+
+658
+00:20:49,359 --> 00:20:52,798
+threat actor movements in to account 
+
+660
+00:20:52,798 --> 00:20:56,400
+that's an even more lax use case 
+
+662
+00:20:56,400 --> 00:21:02,159
+where you care about whether something is a fresh indicator still or not
+
+664
+00:21:00,79 --> 00:21:03,439
+even less than the other two groups.
+
+665
+00:21:02,159 --> 00:21:04,880
+The reason for that is you're interested in
+
+666
+00:21:03,440 --> 00:21:07,120
+the historical movements of a threat actor, for example.
+
+668
+00:21:07,119 --> 00:21:11,439
+So even if something is no longer
+
+669
+00:21:08,240 --> 00:21:13,38
+an indicator because and an infected
+
+670
+00:21:11,440 --> 00:21:14,960
+website was cleaned up
+
+671
+00:21:13,38 --> 00:21:17,38
+since the time when the indicator was
+
+672
+00:21:14,960 --> 00:21:18,880
+shared they still want to see
+
+673
+00:21:17,38 --> 00:21:20,558
+how long, for example a threat actor was
+
+674
+00:21:18,880 --> 00:21:22,80
+using that infrastructure,
+
+675
+00:21:20,558 --> 00:21:25,119
+how quickly they changed to something
+
+676
+00:21:22,79 --> 00:21:27,519
+else and what methods they used
+
+677
+00:21:25,119 --> 00:21:28,239
+back when they were exploiting it. 
+
+679
+00:21:27,240 --> 00:21:31,839
+So if you bring these different requirements on board on
+
+680
+00:21:30,480 --> 00:21:36,959
+the same platform is difficult and there are some
+
+682
+00:21:35,200 --> 00:21:38,960
+things that we can do to alleviate these
+
+683
+00:21:36,960 --> 00:21:40,720
+issues. For example what we do with
+
+684
+00:21:38,960 --> 00:21:42,798
+MISP
+
+685
+00:21:40,720 --> 00:21:44,480
+we have a system called warning list
+
+686
+00:21:42,798 --> 00:21:46,480
+system that allows us to filter out
+
+687
+00:21:44,480 --> 00:21:50,640
+obvious false positives
+
+688
+00:21:46,480 --> 00:21:54,798
+so we maintain these lists of
+
+689
+00:21:50,640 --> 00:21:56,720
+most common websites, empty hash lists,
+
+690
+00:21:54,798 --> 00:21:58,319
+public dns resolvers and all these
+
+691
+00:21:56,720 --> 00:22:00,558
+typical things that end up in
+
+692
+00:21:58,319 --> 00:22:04,399
+the sets while doing automatic extraction for example
+
+694
+00:22:02,400 --> 00:22:06,80
+that end up being false positives but
+
+695
+00:22:04,400 --> 00:22:07,720
+with that said this is just one part of the story
+
+697
+00:22:06,720 --> 00:22:10,79
+So if you're looking at the different
+
+698
+00:22:08,480 --> 00:22:12,880
+use cases up there that doesn't solve our issue
+
+700
+00:22:10,880 --> 00:22:15,600
+of having different requirements
+
+701
+00:22:14,0 --> 00:22:17,558
+1334 --> 1336.559
+from the data set based on what you do with it
+
+703
+00:22:16,558 --> 00:22:20,319
+and this is where contextualization
+
+704
+00:22:18,558 --> 00:22:22,158
+becomes more important again
+
+705
+00:22:20,319 --> 00:22:24,0
+1340.32 --> 1344
+if we can supply the information together with the data,
+
+707
+00:22:23,0 --> 00:22:26,880
+1344 --> 1346.88
+why this data is relevant and what context you're
+
+708
+00:22:25,440 --> 00:22:28,640
+supposed to be using it
+
+709
+00:22:26,880 --> 00:22:30,480
+then the consumers of the data can make
+
+710
+00:22:28,640 --> 00:22:33,440
+those decisions for themselves based on
+
+711
+00:22:30,480 --> 00:22:35,279
+whatever they want to use
+
+712
+00:22:33,440 --> 00:22:38,640
+the data for in any of those different use cases
+
+714
+00:22:36,640 --> 00:22:42,720
+so one of our main efforts with MISP has been
+
+716
+00:22:40,720 --> 00:22:44,0
+1360.72 --> 1364
+to be able to provide these different
+
+717
+00:22:42,400 --> 00:22:47,519
+structures together with the data and to
+
+718
+00:22:44,0 --> 00:22:48,519
+1364 --> 1367.52
+be able to label data well enough. Back to you. 
+
+720
+00:22:48,880 --> 00:22:54,720
+Yeah so and that's iI think important regarding the
+
+721
+00:22:52,960 --> 00:22:56,720
+different kind of use cases and so on
+
+722
+00:22:54,720 --> 00:22:59,360
+and we try to support those different use cases and
+
+725
+00:22:59,759 --> 00:23:03,679
+that's sometimes challenging for us but luckily
+
+726
+00:23:01,679 --> 00:23:06,320
+we are at the same time
+
+727
+00:23:03,679 --> 00:23:07,840
+part of various community so we can see
+
+728
+00:23:06,319 --> 00:23:09,279
+the different use cases, especially
+
+729
+00:23:07,839 --> 00:23:13,480
+regarding the handling of false positive which is
+
+731
+00:23:12,480 --> 00:23:16,558
+an ongoing challenge but we will show
+
+732
+00:23:14,880 --> 00:23:17,840
+you how to handle that
+
+733
+00:23:16,558 --> 00:23:20,0
+1396.559 --> 1400
+and at the same time we basically
+
+734
+00:23:17,839 --> 00:23:22,79
+operate those different communities.
+
+735
+00:23:20,0 --> 00:23:24,159
+1400 --> 1404.159
+So for example we operate a pretty large
+
+736
+00:23:22,79 --> 00:23:26,798
+one for the private sector
+
+737
+00:23:24,159 --> 00:23:30,559
+where we have a lot of organizations,
+
+739
+00:23:28,558 --> 00:23:32,158
+more than 1200 organizations are basically connected there.
+
+740
+00:23:30,880 --> 00:23:35,440
+It's pretty large and we see an active
+
+742
+00:23:35,440 --> 00:23:38,400
+community sharing information and
+
+743
+00:23:36,798 --> 00:23:40,400
+there is plenty of different communities
+
+744
+00:23:38,400 --> 00:23:41,840
+some that we don't know even about
+
+745
+00:23:40,400 --> 00:23:43,278
+because you can even run your own
+
+746
+00:23:41,839 --> 00:23:44,558
+private communities without telling anyone, that's fine.
+
+
+748
+00:23:44,558 --> 00:23:49,759
+That's part of the system but if you want to have different kind of communities
+
+750
+00:23:48,759 --> 00:23:55,839
+you can connect those automatically then you have I would say
+
+753
+00:23:54,240 --> 00:23:57,798
+different kind of model you have those kind of
+
+755
+00:23:56,798 --> 00:24:00,480
+fully island mode communities. 
+
+756
+00:23:58,798 --> 00:24:01,679
+Those kind of trusted groups so for example for the 
+
+758
+00:24:00,679 --> 00:24:05,519
+intelligence community it's very common for them to run MISP
+
+759
+00:24:03,759 --> 00:24:09,759
+in an island mode so having air gap system and so on
+
+761
+00:24:07,759 --> 00:24:11,919
+sometimes they are partially connected
+
+762
+00:24:09,759 --> 00:24:13,599
+with third parties to share partial
+
+763
+00:24:11,919 --> 00:24:15,400
+information so for example we know some organizations
+
+765
+00:24:14,400 --> 00:24:18,640
+or for example border controls or customs
+
+767
+00:24:18,640 --> 00:24:21,919
+are using MISP but they still need to
+
+768
+00:24:20,79 --> 00:24:24,319
+share some small information and that
+
+770
+00:24:22,319 --> 00:24:24,158
+partially connected system. 
+
+771
+00:24:23,319 --> 00:24:28,0
+1464.32 --> 1468
+MISP freely supports those kind of models
+
+772
+00:24:26,159 --> 00:24:29,679
+and then you have community that are
+
+773
+00:24:28,0 --> 00:24:31,359
+1468 --> 1471.36
+more broad and more large
+
+774
+00:24:29,679 --> 00:24:33,278
+for example in the financial sector and
+
+775
+00:24:31,359 --> 00:24:35,240
+I think the CSIRT Luxembourg has some banks
+
+777
+00:24:34,240 --> 00:24:39,599
+we are involved in various sharing communities
+
+779
+00:24:37,599 --> 00:24:41,519
+at European level and worldwide level
+
+780
+00:24:40,480 --> 00:24:45,759
+where for example we know some ISACs that are dedicated to
+
+782
+00:24:43,759 --> 00:24:48,200
+the financial sector are using it as a sharing mechanism 
+
+784
+00:24:47,200 --> 00:24:51,278
+you have some organizations that are really
+
+785
+00:24:49,38 --> 00:24:52,480
+dedicated to a payment processing system
+
+786
+00:24:51,278 --> 00:24:54,519
+that are using this to share automatically
+
+788
+00:24:53,519 --> 00:24:57,519
+information and so on or analysis
+
+790
+00:24:57,519 --> 00:25:01,519
+One of the i would say pretty large community too is
+
+791
+00:24:59,278 --> 00:25:04,960
+with the military organization and international organizations
+
+793
+00:25:02,960 --> 00:25:06,720
+FIRST for example, you have a lot of FIRST members using
+
+794
+00:25:05,359 --> 00:25:08,639
+MISP for sharing their information
+
+796
+00:25:08,640 --> 00:25:13,759
+but there are plenty of networks, national governmental networks
+
+798
+00:25:11,759 --> 00:25:15,278
+a military one intelligence, one or even NATO for example are using
+
+800
+00:25:15,278 --> 00:25:19,599
+using MISP so maybe some of you are eligible to access those ones
+
+802
+00:25:19,599 --> 00:25:23,399
+so we have on the MISP an interface a way to connect to those
+
+804
+00:25:22,400 --> 00:25:26,240
+community and you can reach out to the
+
+805
+00:25:24,319 --> 00:25:27,200
+different community by asking for access for example
+
+807
+00:25:27,200 --> 00:25:30,319
+then you have very specific communities
+
+808
+00:25:28,960 --> 00:25:33,720
+that are set up by security vendors it's not uncommon
+
+810
+00:25:32,720 --> 00:25:35,759
+tp see for example a security vendor
+
+811
+00:25:34,0 --> 00:25:37,359
+1534 --> 1537.36
+services their own MISP
+
+812
+00:25:35,759 --> 00:25:39,119
+we have seen for example some
+
+813
+00:25:37,359 --> 00:25:41,319
+{inaudible} agents vendors running a dedicated MISP
+
+815
+00:25:40,319 --> 00:25:44,480
+or even some operators of specific cloud
+
+816
+00:25:42,798 --> 00:25:46,400
+services running a MISP instance
+
+817
+00:25:44,480 --> 00:25:49,360
+to share information amongst
+
+818
+00:25:46,400 --> 00:25:49,320
+their different customers.
+
+819
+00:25:49,359 --> 00:25:52,798
+Then you have communities that are
+
+820
+00:25:50,319 --> 00:25:55,38
+i would say very specific on the topic
+
+821
+00:25:52,798 --> 00:25:59,79
+for example you have about sick information uh false news
+
+823
+00:25:58,79 --> 00:26:02,278
+and stuff like that you have communities doing that
+
+825
+00:26:01,278 --> 00:26:04,720
+for example we cooperate one called the COVID-19 MISP
+
+827
+00:26:04,720 --> 00:26:09,839
+which is really targeting COVID-19 as a topic 
+
+828
+00:26:07,919 --> 00:26:10,720
+and then you have 10 different subtopics like 
+
+829
+00:26:09,839 --> 00:26:12,399
+cyber security, health related topics and so on.
+
+831
+00:26:12,400 --> 00:26:15,679
+So you can see that MISP can be really used on
+
+832
+00:26:13,919 --> 00:26:17,440
+different model of communities
+
+833
+00:26:15,679 --> 00:26:19,440
+you can bridge those communities,
+
+834
+00:26:17,440 --> 00:26:21,360
+you can interconnect those with together,
+
+835
+00:26:19,440 --> 00:26:23,759
+you can keep it for yourself, so it's
+
+836
+00:26:21,359 --> 00:26:25,839
+really a matter of models.
+
+837
+00:26:23,759 --> 00:26:27,759
+Worldwide there are I would say a lot of
+
+838
+00:26:25,839 --> 00:26:31,199
+communities that we are not aware of
+
+839
+00:26:27,759 --> 00:26:33,599
+but we as CIRCL operates
+
+840
+00:26:31,200 --> 00:26:35,120
+around 20 communities nowadays, that you
+
+841
+00:26:33,599 --> 00:26:37,839
+can basically get access
+
+842
+00:26:35,119 --> 00:26:39,839
+and Andras just sharing in the chat the
+
+843
+00:26:37,839 --> 00:26:42,439
+access to the COVID-19 MISP and if you want to get access to
+
+845
+00:26:41,440 --> 00:26:46,320
+that one you can connect on the main page and self-register and
+
+847
+00:26:46,319 --> 00:26:49,519
+you can request access to that community 
+
+849
+00:26:48,519 --> 00:26:53,38
+so you see that MISP has different groups different communities
+
+851
+00:26:53,38 --> 00:26:56,640
+and it's up to you at the end to decide
+
+852
+00:26:55,359 --> 00:26:58,879
+which kind of community you want to {inaudiable either be/visit}
+
+854
+00:27:01,38 --> 00:27:04,798
+So, a little bit besides all the technical things
+
+856
+00:27:04,798 --> 00:27:06,839
+that we talked about, that we do with MISP,
+
+857
+00:27:06,480 --> 00:27:09,919
+and that we try to solve with it.
+
+858
+00:27:07,839 --> 00:27:11,278
+In terms of sharing, there are obviously
+
+859
+00:27:09,919 --> 00:27:12,720
+going to be other hurdles that you have
+
+860
+00:27:11,278 --> 00:27:14,159
+to overcome whenever it comes to information sharing
+
+862
+00:27:14,159 --> 00:27:17,679
+one of the the toughest things to
+
+863
+00:27:16,0 --> 00:27:18,880
+1636 --> 1638.88
+overcome and this is where no tool can really help you
+
+865
+00:27:18,880 --> 00:27:23,679
+is to get enough trust in a community to
+
+866
+00:27:22,79 --> 00:27:24,319
+be able to share your information with them
+
+868
+00:27:24,319 --> 00:27:27,918
+So the only way to facilitate this is really social interactions
+
+870
+00:27:27,919 --> 00:27:32,0
+1647.919 --> 1652
+so sadly though we're living in times
+
+871
+00:27:30,398 --> 00:27:33,278
+where social interactions are tougher than usual
+
+873
+00:27:33,278 --> 00:27:37,440
+but for example events like FIRST conferences
+
+874
+00:27:35,679 --> 00:27:38,880
+ are great ways to get to know your community and to
+
+876
+00:27:38,880 --> 00:27:43,200
+build this trust and build those
+
+877
+00:27:41,440 --> 00:27:44,159
+social relationships that you need 
+
+879
+00:27:44,159 --> 00:27:47,679
+to be able to really exchange meaningful
+
+880
+00:27:45,839 --> 00:27:49,918
+information with the community
+
+881
+00:27:47,679 --> 00:27:52,0
+1667.679 --> 1672
+so i really encourage everyone that
+
+882
+00:27:49,919 --> 00:27:53,360
+wants to partake in information sharing communities
+
+884
+00:27:53,359 --> 00:27:57,278
+to be social, to reach out, and to get to know your community
+
+886
+00:27:57,278 --> 00:28:00,79
+because that's the biggest facilitator for sharing in the first place.
+
+888
+00:28:00,79 --> 00:28:03,599
+Other than that, there are obviously some
+
+889
+00:28:01,919 --> 00:28:05,360
+legal restrictions that you have
+
+890
+00:28:03,599 --> 00:28:06,398
+that might come up in the entire process.
+
+891
+00:28:05,359 --> 00:28:08,79
+We see this very often with organizations where the first
+
+893
+00:28:08,79 --> 00:28:10,918
+questions that they ask us when they join
+
+895
+00:28:09,919 --> 00:28:16,240
+in our communities okay how does this
+
+896
+00:28:13,38 --> 00:28:18,558
+fit into GDPR for example.
+
+897
+00:28:16,240 --> 00:28:21,38
+If my legal team asks me why I am sharing
+
+898
+00:28:18,558 --> 00:28:22,720
+an information out what can i
+
+899
+00:28:21,38 --> 00:28:24,798
+give them as an explanation of why i'm
+
+900
+00:28:22,720 --> 00:28:25,159
+supposed to or allowed to do this.
+
+901
+00:28:25,198 --> 00:28:28,319
+So if you need any help with that we
+
+902
+00:28:26,159 --> 00:28:29,840
+have a bunch of compliance documentation
+
+903
+00:28:28,319 --> 00:28:33,240
+and that we've been working on together with a bunch of partners
+
+905
+00:28:32,240 --> 00:28:36,798
+and so we have descriptions for how
+
+906
+00:28:34,640 --> 00:28:37,919
+MISP fits into the GDPR, the NIS directive
+
+908
+00:28:37,919 --> 00:28:41,360
+and some other frameworks so just
+
+909
+00:28:40,79 --> 00:28:43,119
+have a look there and if you have any
+
+910
+00:28:41,359 --> 00:28:44,0
+1721.36 --> 1724
+questions or if you feel that anything is not covered
+
+912
+00:28:44,0 --> 00:28:47,599
+1724 --> 1727.6
+let us know and we keep updating our documentation
+
+914
+00:28:47,599 --> 00:28:51,519
+based on on feedback of what's missing
+
+915
+00:28:49,679 --> 00:28:52,559
+or ideas that we should be incorporating in there
+
+917
+00:28:52,558 --> 00:29:00,640
+but generally , once your legal team is more
+
+919
+00:28:58,880 --> 00:29:01,360
+familiar with the process and why this
+
+920
+00:29:00,640 --> 00:29:02,80
+is {inaudiable done/tied}
+
+921
+00:29:01,359 --> 00:29:05,759
+why ensuring security for your
+
+922
+00:29:04,79 --> 00:29:06,798
+organization and for the data that you
+
+923
+00:29:05,759 --> 00:29:08,960
+have to secure is important then it's seen more as a
+
+925
+00:29:08,960 --> 00:29:13,360
+benefit than a hurdle really
+
+926
+00:29:10,640 --> 00:29:15,278
+but it obviously takes time to get
+
+927
+00:29:13,359 --> 00:29:16,240
+this into your processes to define why you're
+
+929
+00:29:16,240 --> 00:29:19,679
+doing what you're doing
+
+930
+00:29:18,398 --> 00:29:21,199
+your retention periods,
+
+931
+00:29:19,679 --> 00:29:22,960
+describing how you're going to handle data and so on
+
+933
+00:29:22,960 --> 00:29:26,399
+so this obviously has some ramp up time
+
+935
+00:29:26,398 --> 00:29:29,439
+but we have a lot of documentation that will help you with that. 
+
+937
+00:29:29,440 --> 00:29:32,558
+There are also some practical restrictions that we hear from
+
+938
+00:29:30,960 --> 00:29:34,79
+organizations so very often when
+
+939
+00:29:32,558 --> 00:29:35,440
+organizations reach out to us
+
+940
+00:29:34,79 --> 00:29:37,199
+the first thing they say is we don't
+
+941
+00:29:35,440 --> 00:29:39,120
+really have any information to share,
+
+942
+00:29:37,200 --> 00:29:40,880
+we don't have the capability for example
+
+943
+00:29:39,119 --> 00:29:42,639
+to build those highly vetted threat reports that we're so used to
+
+945
+00:29:42,640 --> 00:29:46,960
+from feed providers and obviously very few organizations do.
+
+947
+00:29:46,960 --> 00:29:51,200
+With that said information sharing comes
+
+948
+00:29:49,919 --> 00:29:54,600
+in many different shapes and sizes for example going back
+
+950
+00:29:53,599 --> 00:29:58,558
+to the initial use case about
+
+951
+00:29:55,200 --> 00:30:00,0
+1795.2 --> 1800
+providing feedback from your analysts
+
+952
+00:29:58,558 --> 00:30:02,240
+about the data that you receive from
+
+953
+00:30:00,0 --> 00:30:03,839
+1800 --> 1803.84
+your community is already valuable
+
+954
+00:30:02,240 --> 00:30:05,599
+information sharing so if someone for
+
+955
+00:30:03,839 --> 00:30:07,278
+example provides sightings
+
+956
+00:30:05,599 --> 00:30:09,839
+I've also seen this indicator at this given time
+
+958
+00:30:09,839 --> 00:30:13,359
+that can already help you tune the data set
+
+960
+00:30:13,359 --> 00:30:16,879
+for what goes into your working data
+
+961
+00:30:15,119 --> 00:30:18,319
+sets for detection and blocking and so on.
+
+963
+00:30:18,319 --> 00:30:22,960
+Also providing information on false
+
+964
+00:30:20,839 --> 00:30:24,319
+positives and some information that
+
+965
+00:30:22,960 --> 00:30:26,640
+you provided to the community turns out to be false
+
+967
+00:30:26,640 --> 00:30:30,960
+or something that is no longer relevant
+
+968
+00:30:28,880 --> 00:30:33,39
+getting information that is valid as
+
+969
+00:30:30,960 --> 00:30:35,278
+well so pretty much everyone has
+
+970
+00:30:33,38 --> 00:30:36,398
+information to share by just using the information and running
+
+972
+00:30:36,398 --> 00:30:44,0
+1836.399 --> 1844
+into frustration with the data by itself.
+
+973
+00:30:40,720 --> 00:30:44,640
+Also besides not having information to share
+
+975
+00:30:44,640 --> 00:30:50,399
+there comes also the issue of time.
+
+976
+00:30:48,398 --> 00:30:51,759
+Most of us are overburdened with
+
+977
+00:30:50,398 --> 00:30:52,798
+the different tasks that we are facing nowadays
+
+979
+00:30:52,798 --> 00:30:57,599
+so taking extra time out of the day to
+
+981
+00:30:57,599 --> 00:31:02,38
+encode information and to share it out in the community
+
+983
+00:31:01,38 --> 00:31:04,558
+is obviously going to be an extra burden
+
+984
+00:31:02,640 --> 00:31:05,600
+there is no way around it. 
+
+985
+00:31:03,558 --> 00:31:07,440
+What we try to do with MISP
+
+986
+00:31:05,599 --> 00:31:09,38
+is to make this process as minimal as
+
+987
+00:31:07,440 --> 00:31:11,0
+1867.44 --> 1870
+possible but it is going to be a time investment in the end, after all
+
+989
+00:31:10,0 --> 00:31:13,839
+1870 --> 1873.84
+especially if you want to vet the data if you want to ensure that 
+
+992
+00:31:13,839 --> 00:31:19,240
+the right data reaches the right recipients
+
+994
+00:31:18,240 --> 00:31:26,240
+This always has a time drain on you as well but in return this
+
+996
+00:31:24,480 --> 00:31:29,79
+is offset by what you gain by sharing that information we're
+
+998
+00:31:28,79 --> 00:31:31,359
+going to talk about this a little bit
+
+999
+00:31:29,440 --> 00:31:33,759
+more during the community building part
+
+1000
+00:31:31,359 --> 00:31:35,278
+about what effects you're going to see
+
+1001
+00:31:33,759 --> 00:31:36,640
+if you're sharing information and why it is relevant for you
+
+1003
+00:31:36,640 --> 00:31:41,120
+but to basically sum it up in one sentence
+
+1005
+00:31:41,119 --> 00:31:44,239
+and whatever affects your organization
+
+1006
+00:31:42,960 --> 00:31:45,679
+is probably the most important information for you and if you get
+
+1008
+00:31:45,679 --> 00:31:49,759
+feedback on that, what you're seeing in your network
+
+1010
+00:31:49,759 --> 00:31:52,398
+and more eyes on it, more perspectives
+
+1013
+00:31:52,398 --> 00:31:58,159
+and perhaps more sophisticated methods of
+
+1014
+00:31:56,79 --> 00:31:59,519
+research from other organizations
+
+1015
+00:31:58,159 --> 00:32:01,600
+then that will probably just improve
+
+1016
+00:31:59,519 --> 00:32:03,519
+your own security posture the best way it can.
+
+1018
+00:32:03,519 --> 00:32:08,880
+Now, besides timeliness and basically having information to share
+
+1020
+00:32:07,519 --> 00:32:10,960
+there's also the issue of different
+
+1021
+00:32:08,880 --> 00:32:12,240
+classification models so classification
+
+1022
+00:32:10,960 --> 00:32:16,159
+not just in a sense of of deciding who we share information with
+
+1025
+00:32:16,159 --> 00:32:19,278
+but how we classify information really
+
+1026
+00:32:18,79 --> 00:32:22,798
+in terms of contextualizating it we are all used
+
+1029
+00:32:22,798 --> 00:32:28,159
+to naming things a certain way in our organizations in
+
+1030
+00:32:26,319 --> 00:32:31,38
+our communities and we've probably
+
+1031
+00:32:28,159 --> 00:32:35,839
+been doing it for longer than digital information systems exist 
+
+1034
+00:32:34,558 --> 00:32:37,599
+so we're probably using a lot of those
+
+1035
+00:32:35,839 --> 00:32:38,639
+vocabularies that we've been using for decades
+
+1037
+00:32:38,640 --> 00:32:43,600
+and what one of the things that we
+
+1038
+00:32:41,119 --> 00:32:45,678
+wanted to avoid with MISP is to
+
+1039
+00:32:43,599 --> 00:32:46,639
+get these communities to switch to a
+
+1041
+00:32:46,640 --> 00:32:51,360
+different way of describing things so if you already
+
+1042
+00:32:49,119 --> 00:32:52,959
+have your set methods, your set processes
+
+1043
+00:32:51,359 --> 00:32:54,479
+how you define things, we don't want to alter that so one of
+
+1045
+00:32:54,480 --> 00:32:57,278
+the things that we do with MISP and we are
+
+1046
+00:32:55,839 --> 00:32:58,798
+going to talk a fair bit about, tomorrow mostly
+
+1048
+00:32:58,798 --> 00:33:03,679
+is that you have ways to describe your
+
+1049
+00:33:01,519 --> 00:33:06,0
+1981.519 --> 1986
+own taxonomies and your own vocabularies
+
+1050
+00:33:03,679 --> 00:33:07,120
+to use those in your community so very
+
+1051
+00:33:06,0 --> 00:33:08,558
+1986 --> 1988.559
+often when you're spinning up a
+
+1052
+00:33:07,119 --> 00:33:09,199
+community and when you're starting out
+
+1053
+00:33:08,558 --> 00:33:10,879
+with the sharing community,
+
+1055
+00:33:10,880 --> 00:33:14,320
+a national sharing community, sectorial one, whatever
+
+1056
+00:33:12,480 --> 00:33:16,399
+then one of the first tasks is basically
+
+1057
+00:33:14,319 --> 00:33:18,720
+defining those common vocabularies
+
+1058
+00:33:16,398 --> 00:33:20,639
+that you're going to be using
+
+1059
+00:33:18,720 --> 00:33:22,319
+now apart from the vocabularies
+
+1060
+00:33:20,640 --> 00:33:25,38
+themselves there is also the issue of
+
+1061
+00:33:22,319 --> 00:33:25,839
+of us speaking many different languages
+
+1063
+00:33:25,839 --> 00:33:29,519
+in terms of of our tools using different formats
+
+1065
+00:33:28,640 --> 00:33:33,919
+so that means even within our own organization which is
+
+1066
+00:33:32,79 --> 00:33:34,639
+rather small we have a set of different tools
+
+1068
+00:33:34,640 --> 00:33:38,559
+that will ingest data in different formats
+
+1070
+00:33:38,558 --> 00:33:42,240
+or will prefer to ingest data in given
+
+1071
+00:33:40,558 --> 00:33:43,119
+format so one of the things we also try to do with MISP
+
+1073
+00:33:43,119 --> 00:33:46,798
+is to act as a hub for all your different tools
+
+1075
+00:33:46,798 --> 00:33:51,519
+that will get their data translated into
+
+1076
+00:33:49,200 --> 00:33:52,960
+the format that they can best ingest.
+
+1077
+00:33:51,519 --> 00:33:55,839
+Obviously this is something where we cannot be completely
+
+1079
+00:33:55,839 --> 00:34:01,519
+100 percent covering all the other
+
+1080
+00:33:59,119 --> 00:34:02,879
+things that exist out there. 
+
+1081
+00:34:01,519 --> 00:34:04,558
+So one of the things we try to do with MISP
+
+1082
+00:34:02,880 --> 00:34:06,399
+is make it as modular as possible and
+
+1083
+00:34:04,558 --> 00:34:07,278
+it's easy to encode your own formats as possible.
+
+1085
+00:34:07,278 --> 00:34:13,440
+We're not going to go deeply into how to do this during the training
+
+1087
+00:34:11,358 --> 00:34:15,39
+but if anyone is interested about that just
+
+1089
+00:34:15,39 --> 00:34:17,599
+let us know and we'll point you in the
+
+1090
+00:34:16,398 --> 00:34:19,598
+right direction where you can find
+
+1091
+00:34:17,599 --> 00:34:20,159
+documentation on how to modularize and
+
+1093
+00:34:19,599 --> 00:34:24,159
+how to build import and export in MISP.
+
+1094
+00:34:26,760 --> 00:34:30,560
+So just one side note, all the training
+
+1095
+00:34:28,639 --> 00:34:32,320
+materials are available online
+
+1096
+00:34:30,559 --> 00:34:33,599
+like {inaduiable} mentioned we have a Github
+
+1097
+00:34:32,320 --> 00:34:35,599
+repository with a pretty extensive README files with all
+
+1099
+00:34:35,599 --> 00:34:41,39
+the material that we provide, there is a MISP book too which includes a
+
+1101
+00:34:41,39 --> 00:34:45,838
+lot of reference to MISP as you know MISP has a 
+
+1103
+00:34:45,838 --> 00:34:50,159
+pretty large topic coming from technical aspect and
+
+1105
+00:34:50,159 --> 00:34:54,480
+you will see that in a minute about the project overview.
+
+1107
+00:34:54,480 --> 00:34:57,519
+So don't hesitate to go there on the MISP training
+
+1109
+00:34:57,519 --> 00:35:00,639
+page on Github this one is a good
+
+1110
+00:34:59,358 --> 00:35:02,639
+reference because it's really pointing
+
+1111
+00:35:00,639 --> 00:35:05,920
+to the different elements
+
+1112
+00:35:02,639 --> 00:35:06,239
+that we have. We have a huge slide deck of
+
+1114
+00:35:06,239 --> 00:35:10,559
+close to 500 pages of slide deck on the
+
+1115
+00:35:08,559 --> 00:35:11,679
+MISP book we have close to 500 pages. I
+
+1116
+00:35:10,559 --> 00:35:13,440
+would not mention the number of pages
+
+1117
+00:35:11,679 --> 00:35:14,719
+for taxonomies, galaxies and so on. It's quite large too
+
+1119
+00:35:14,719 --> 00:35:19,39
+but really look at this as a kind of way
+
+1120
+00:35:17,519 --> 00:35:22,239
+to shape it to what you like.
+
+1121
+00:35:19,39 --> 00:35:23,519
+So it's really there to help you and if
+
+1122
+00:35:22,239 --> 00:35:25,439
+you see something missing
+
+1123
+00:35:23,519 --> 00:35:26,800
+let us know but we have slides, 
+
+1125
+00:35:26,800 --> 00:35:31,200
+for example system requirements, things like
+
+1126
+00:35:29,838 --> 00:35:32,960
+for example building community that
+
+1127
+00:35:31,199 --> 00:35:35,439
+we'll talk tomorrow, that's
+
+1128
+00:35:32,960 --> 00:35:37,599
+part of it but for more the
+
+1129
+00:35:35,440 --> 00:35:40,320
+programmatic aspect, API
+
+1130
+00:35:37,599 --> 00:35:41,200
+how to integrate with MISP {inaduiable JSON/taxono},
+
+1131
+00:35:40,320 --> 00:35:43,39
+how to extend it too
+
+1132
+00:35:41,199 --> 00:35:44,799
+there are plenty of slides regarding that
+
+1133
+00:35:43,39 --> 00:35:46,800
+so it's really a good reference
+
+1134
+00:35:44,800 --> 00:35:48,560
+and thanks to {inaduiable} to share this
+
+1135
+00:35:46,800 --> 00:35:50,800
+information on the chat
+
+1136
+00:35:48,559 --> 00:35:52,719
+so to just give a quick overview of the MISP project and really to show that
+
+1138
+00:35:52,719 --> 00:35:56,399
+the project is quite large nowadays
+
+1139
+00:35:55,199 --> 00:35:59,838
+we basically have like four pillars of things in MISP
+
+1141
+00:35:59,838 --> 00:36:03,199
+one is obviously the open software itself
+
+1143
+00:36:03,199 --> 00:36:08,78
+so the initial version in {inaduaible} it was
+
+1144
+00:36:06,239 --> 00:36:10,239
+the small first small block there
+
+1145
+00:36:08,79 --> 00:36:11,440
+the MISP core software which is like just the software
+
+1147
+00:36:11,440 --> 00:36:16,400
+mainly for the LMAP aspect where
+
+1148
+00:36:14,800 --> 00:36:17,920
+you have the backend, the web interface,
+
+1149
+00:36:16,400 --> 00:36:19,760
+and so on but over the time the project extended
+
+1151
+00:36:19,760 --> 00:36:23,40
+with multiple things so if you look on the Github
+
+1152
+00:36:20,960 --> 00:36:24,800
+repository of mid project we have around 50 repositories so
+
+1154
+00:36:24,800 --> 00:36:28,720
+it's pretty large. Just to summarize what
+
+1155
+00:36:27,519 --> 00:36:31,119
+are the different one
+
+1156
+00:36:28,719 --> 00:36:31,919
+we have for example the MISP modules um
+
+1158
+00:36:31,920 --> 00:36:35,119
+which is an easy way to extend MISP so the behavior of MISP
+
+1160
+00:36:35,119 --> 00:36:40,880
+on the expansion side on the import, export and so on by just writing
+
+1162
+00:36:40,880 --> 00:36:44,480
+python modules it's super easy to develop and use
+
+1164
+00:36:44,480 --> 00:36:47,920
+and the idea behind is obviously to
+
+1165
+00:36:46,0 --> 00:36:50,960
+2206 --> 2210.96
+extend MISP without knowing
+
+1166
+00:36:47,920 --> 00:36:51,440
+the core details about the system 
+
+1167
+00:36:50,960 --> 00:36:55,358
+then we have a library called PyMISP and this
+
+1168
+00:36:53,440 --> 00:36:58,639
+PyMISP library is basically a
+
+1169
+00:36:55,358 --> 00:37:02,319
+python library to expose the new MISP platform API
+
+1171
+00:37:02,320 --> 00:37:07,39
+so MISP has a large REST api this one can be quite large but
+
+1173
+00:37:05,199 --> 00:37:11,679
+by MISP is really helping you to for example {inaduiable jest/Get} events
+
+1174
+00:37:09,599 --> 00:37:13,200
+create feeds and stuff like that so it's
+
+1175
+00:37:11,679 --> 00:37:15,358
+really important if you want to
+
+1176
+00:37:13,199 --> 00:37:17,39
+extend MISP to have a look at PyMISP that
+
+1177
+00:37:15,358 --> 00:37:18,480
+is not the only library for extending
+
+1179
+00:37:18,480 --> 00:37:23,440
+MISP some in golang you have some
+
+1180
+00:37:21,519 --> 00:37:24,639
+other in python too, you have others in java and so on
+
+1182
+00:37:24,639 --> 00:37:28,0
+2244.64 --> 2248
+but the PyMISP one is the one that
+
+1183
+00:37:26,400 --> 00:37:31,199
+is maintained by the author of MISP so it is maintained by us
+
+1186
+00:37:31,199 --> 00:37:34,399
+and you can have a look at this one it's
+
+1187
+00:37:32,480 --> 00:37:36,0
+2252.48 --> 2256
+really the one that's up to date it's
+
+1188
+00:37:34,400 --> 00:37:38,0
+2254.4 --> 2258
+really core and part of the system too
+
+1189
+00:37:36,0 --> 00:37:40,400
+2256 --> 2260.4
+because we use it for our own tests
+
+1190
+00:37:38,0 --> 00:37:42,320
+2258 --> 2262.32
+within MISP then we have different
+
+1191
+00:37:40,400 --> 00:37:43,358
+repository i will just mention one which is
+
+1193
+00:37:43,358 --> 00:37:46,559
+dashboard, the dashboard is an extension module
+
+1195
+00:37:46,559 --> 00:37:51,838
+in MISP using what we call the ZeroMQ feed in MISP
+
+1196
+00:37:49,838 --> 00:37:54,159
+so we have a kind of way to have kind of a real-time feed
+
+1198
+00:37:54,159 --> 00:37:58,799
+in MISP you can {inaudiable} and
+
+1199
+00:37:56,400 --> 00:38:00,639
+so on but we wanted to show an example
+
+1200
+00:37:58,800 --> 00:38:02,240
+application for that and the MISP
+
+1201
+00:38:00,639 --> 00:38:04,879
+dashboard is exactly that
+
+1202
+00:38:02,239 --> 00:38:06,559
+is a way to really get all the
+
+1203
+00:38:04,880 --> 00:38:08,960
+information that you have in MISP
+
+1204
+00:38:06,559 --> 00:38:09,920
+into a very nice dashboard and so on
+
+1205
+00:38:08,960 --> 00:38:11,760
+this is really to have a good example of what you can do
+
+1207
+00:38:11,760 --> 00:38:14,240
+with information within MISP and how you can use it
+
+1209
+00:38:14,239 --> 00:38:17,519
+so that's the main pillar you have
+
+1210
+00:38:15,519 --> 00:38:18,79
+plenty of other projects but those one are the main ones
+
+1212
+00:38:18,79 --> 00:38:22,400
+on top of that you have
+
+1213
+00:38:20,880 --> 00:38:23,358
+what we call the intelligent and knowledge database of
+
+1215
+00:38:23,358 --> 00:38:27,119
+MISP and just mentioned about the difficulty
+
+1217
+00:38:27,119 --> 00:38:31,280
+sometimes in some organizations to use a
+
+1218
+00:38:29,199 --> 00:38:33,519
+{inaudiable proper/corporate} classification and so on
+
+1219
+00:38:31,280 --> 00:38:35,40
+and we try to ease this in this
+
+1220
+00:38:33,519 --> 00:38:36,639
+different organization by having a kind
+
+1221
+00:38:35,39 --> 00:38:37,279
+of library of all the taxonomies that exist
+
+1223
+00:38:37,280 --> 00:38:41,519
+so we started as a very simple one where
+
+1224
+00:38:39,679 --> 00:38:43,358
+it was just including for example a
+
+1225
+00:38:41,519 --> 00:38:45,440
+taxonomy like the traffic light protocol one, FIRST is using it
+
+1227
+00:38:45,440 --> 00:38:49,119
+and it's a commonly used classification but over
+
+1228
+00:38:47,838 --> 00:38:50,320
+the time we have seen that many
+
+1229
+00:38:49,119 --> 00:38:52,720
+organizations have different
+
+1230
+00:38:50,320 --> 00:38:54,320
+classification and so on. So we already
+
+1231
+00:38:52,719 --> 00:38:55,838
+in advance we prepare all those taxonomies in
+
+1233
+00:38:55,838 --> 00:38:59,599
+possible information {inaudiable} expose MISP
+
+1234
+00:38:58,159 --> 00:39:02,399
+and you can enable the one that you want
+
+1235
+00:38:59,599 --> 00:39:05,39
+so we have around 150 libraries now
+
+1236
+00:39:02,400 --> 00:39:05,680
+ranging from classifications, specific one for
+
+1238
+00:39:05,679 --> 00:39:10,559
+intelligence communities and some
+
+1239
+00:39:08,159 --> 00:39:12,399
+other activities so this one is our
+
+1240
+00:39:10,559 --> 00:39:13,440
+really useful label and you can just
+
+1241
+00:39:12,400 --> 00:39:15,39
+{inaudiable share/pick} the one that you want and we maintain those one
+
+1243
+00:39:15,39 --> 00:39:18,880
+so we have some that are coming from
+
+1244
+00:39:16,960 --> 00:39:21,39
+third party, some that we are collecting
+
+1245
+00:39:18,880 --> 00:39:23,39
+as each projects are creating.
+
+1246
+00:39:21,39 --> 00:39:24,719
+It's really usually a good source to see
+
+1247
+00:39:23,39 --> 00:39:26,838
+how other communities are using
+
+1248
+00:39:24,719 --> 00:39:28,639
+classifying and contextualizing the
+
+1249
+00:39:26,838 --> 00:39:30,480
+information, there nevertheless the
+
+1250
+00:39:28,639 --> 00:39:35,759
+taxonomy itself was like kind of labels, those labels were quite small
+
+1253
+00:39:33,519 --> 00:39:36,960
+so it was not like completely extensive information so
+
+1255
+00:39:36,960 --> 00:39:41,39
+over the time we maintain a kind of more extensive one called the galaxy
+
+1257
+00:39:41,39 --> 00:39:47,279
+you will hear the term very often
+
+1258
+00:39:44,79 --> 00:39:49,200
+those galaxies are defining many things
+
+1259
+00:39:47,280 --> 00:39:51,40
+for example one of the most common one is the threat actor
+
+1261
+00:39:50,39 --> 00:39:54,400
+we have a huge database of threat actors but a lot of
+
+1262
+00:39:52,800 --> 00:39:56,400
+times it was extended
+
+1263
+00:39:54,400 --> 00:39:58,320
+for example, Microsoft is not using
+
+1264
+00:39:56,400 --> 00:39:59,358
+threat actors for example there is this activity group is part of the
+
+1266
+00:39:59,358 --> 00:40:05,119
+galaxy, it's really one that we
+
+1267
+00:40:02,400 --> 00:40:05,760
+use for different and you can represent whatever
+
+1269
+00:40:05,760 --> 00:40:09,280
+galaxy you want so you have a predefined
+
+1270
+00:40:07,358 --> 00:40:10,960
+set of existing one but you can create your own 
+
+1272
+00:40:10,960 --> 00:40:14,400
+so if you have your own threat actor database
+
+1273
+00:40:12,880 --> 00:40:16,480
+you can create your own from scratch or
+
+1274
+00:40:14,400 --> 00:40:17,280
+you can reuse and fork existing ones so
+
+1275
+00:40:16,480 --> 00:40:18,480
+that's really those kind of things that we manage in
+
+1277
+00:40:18,480 --> 00:40:21,920
+the project is not only code and software
+
+1278
+00:40:20,318 --> 00:40:23,39
+we manage those kind of knowledge base
+
+1280
+00:40:23,39 --> 00:40:27,759
+for intelligent {inaudiable} organization
+
+1281
+00:40:26,79 --> 00:40:29,200
+we have some specific one like the notice list
+
+1283
+00:40:28,899 --> 00:40:32,480
+this one is a pretty small one that you use for the GDPR aspect
+
+1285
+00:40:32,480 --> 00:40:36,480
+but this one can be used for anything you want,
+
+1287
+00:40:35,480 --> 00:40:40,960
+It's for informing the analyst or the user of MISP when he
+
+1288
+00:40:39,358 --> 00:40:41,440
+touched some specific information in MISP
+
+1290
+00:40:41,440 --> 00:40:45,280
+that could impact for example the legal framework and so on
+
+1292
+00:40:44,280 --> 00:40:49,280
+it's actively use in the intelligence community,
+
+1293
+00:40:47,119 --> 00:40:50,960
+law enforcement and so on maybe less in
+
+1294
+00:40:49,280 --> 00:40:52,880
+security operation center but it's
+
+1295
+00:40:50,960 --> 00:40:54,880
+coming more and more due to the legal
+
+1296
+00:40:52,880 --> 00:40:56,240
+side of information sharing and
+
+1297
+00:40:54,880 --> 00:40:58,480
+especially storing information that might contain personal information
+
+1299
+00:40:58,480 --> 00:41:02,480
+then we have another one called the
+
+1300
+00:40:59,679 --> 00:41:08,159
+warning list and Andras quickly mentioned this kind of recurring problems or false positives
+
+1303
+00:41:06,559 --> 00:41:12,719
+and the one in MISP are basically list of existing potential false positives
+
+1305
+1306
+00:41:12,719 --> 00:41:17,439
+for example we have lists of well-known IP addresses from Microsoft, for example.
+
+1308
+00:41:17,440 --> 00:41:20,800
+We have list of things like domain names used by Google and so on
+
+1310
+00:41:20,800 --> 00:41:25,599
+that's already helping users to find out
+
+1311
+00:41:23,519 --> 00:41:27,119
+if something might be a false positive
+
+1312
+00:41:25,599 --> 00:41:28,559
+and we do that automatically and we
+
+1313
+00:41:27,119 --> 00:41:30,800
+maintain those libraries because one {inaudiable MISP/reason} they're automatically updated regularly
+
+1315
+00:41:30,800 --> 00:41:34,79
+I think we have around 50 lists nowadays
+
+1318
+00:41:34,79 --> 00:41:38,160
+It's really useful when you do on a day-to-day basis and creating events and
+
+1320
+00:41:38,159 --> 00:41:41,838
+so on you can really find and spot things that might be a false positive in advance
+
+1323
+00:41:41,838 --> 00:41:48,0
+2503.119 --> 2508
+by having those warning lists enabled
+
+1324
+00:41:45,280 --> 00:41:49,839
+and again it's up to the user to select
+
+1325
+00:41:48,0 --> 00:41:53,39
+2508 --> 2511.04
+one {inaudiable} warning list or to enable everything depending on the different use case
+
+1328
+00:41:52,800 --> 00:41:55,920
+so that's one of those {inaudiable} pillar
+
+1329
+00:41:54,480 --> 00:41:57,519
+knowledge base i mean a lot of
+
+1330
+00:41:55,920 --> 00:41:57,519
+contributions coming from threat parties
+
+1332
+00:41:57,519 --> 00:42:02,480
+are coming from that aspect so it's not really programmers
+
+1333
+00:42:00,719 --> 00:42:03,679
+or coders that are contributing there
+
+1334
+00:42:02,480 --> 00:42:05,599
+but it's more analysts and people doing really threat intelligence
+
+1336
+00:42:05,599 --> 00:42:10,160
+or classification and so on 
+
+1337
+00:42:08,318 --> 00:42:12,79
+is really something that is useful for everyone
+
+1338
+00:42:10,159 --> 00:42:14,159
+without being your direct contributions on the code
+
+1340
+00:42:14,159 --> 00:42:18,719
+then over the times we we we became a kind of de facto standard and
+
+1342
+00:42:18,719 --> 00:42:22,480
+uh nowadays is even more than a de facto standard, is a standard
+
+1344
+00:42:22,480 --> 00:42:27,199
+We published as an interesting engineering task force draft
+
+1346
+00:42:27,199 --> 00:42:31,439
+all those documents especially the core format
+
+1348
+00:42:31,440 --> 00:42:35,200
+and to ease that for the development of external tools
+1350
+00:42:35,199 --> 00:42:39,279
+integration and so on. 
+
+1351
+00:42:38,0 --> 00:42:40,119
+2558 --> 2561.119
+So if you're interested you can go to the
+
+1352
+00:42:39,280 --> 00:42:42,319
+MISP platform website where we describe the different standards that we
+
+1354
+00:42:42,318 --> 00:42:47,199
+published. We even co-host standards that are for people
+
+1356
+00:42:47,199 --> 00:42:51,598
+integrating with MISP
+
+1357
+00:42:50,480 --> 00:42:53,599
+and we have specific standards for example for the object template
+
+1359
+00:42:53,599 --> 00:42:56,800
+and that's something that we will talkabout but that's something that was
+
+1360
+00:42:54,800 --> 00:42:58,79
+
+1361
+00:42:56,800 --> 00:42:59,839
+really a need for us from the early beginning of MISP
+
+1363
+00:42:59,838 --> 00:43:02,799
+a lot of organizations want to have their own structure of information
+
+1365
+00:43:02,800 --> 00:43:06,880
+about objects and so on and we have a flexible model in MISP to
+
+1367
+00:43:06,880 --> 00:43:11,358
+really create your own data models and this one is standardized too
+
+1369
+00:43:11,358 --> 00:43:15,358
+and it's really helping sharing communities to
+
+1371
+00:43:15,358 --> 00:43:20,318
+extend MISP as they wish and their models without breaking the
+
+1373
+00:43:20,318 --> 00:43:24,79
+the standards itself so that's really interesting for for showing you new models
+
+1376
+00:43:24,79 --> 00:43:28,79
+and then next to that we will do everything possible to help community
+
+1378
+00:43:28,79 --> 00:43:31,359
+and Andras just mentioned the question of the
+
+1380
+00:43:31,358 --> 00:43:35,679
+legal aspect and i think maybe some of
+
+1381
+00:43:33,599 --> 00:43:38,640
+you already have this order to
+
+1382
+00:43:35,679 --> 00:43:40,399
+seek legal team about the information sharing policies and so on
+
+1384
+00:43:40,400 --> 00:43:44,880
+we try to make it easier so we publish this kind of compliance document
+
+1386
+00:43:44,880 --> 00:43:48,160
+and so on it's part of the MISP project
+
+1387
+00:43:46,719 --> 00:43:50,879
+everything is open source again so everything we do is open source and
+
+1389
+00:43:50,880 --> 00:43:55,760
+on open access. You can reuse it and so on. We have for example a specific
+
+1391
+00:43:55,760 --> 00:44:01,679
+document about building communities which is something that we do within the X-ISAC project
+
+1394
+00:44:01,679 --> 00:44:08,960
+and it's containing kind of best practices what are kind of agreement that you can
+
+1397
+00:44:08,960 --> 00:44:11,119
+use when doing a setup of sharing communities.
+
+1399
+00:44:11,119 --> 00:44:15,440
+Up to things about how to do contextualization and so on
+
+1400
+00:44:13,280 --> 00:44:17,40
+so that's that's maybe something that
+
+1401
+00:44:15,440 --> 00:44:17,519
+for an organization that wants to boost up an ISAC or sharing communities they can
+
+1404
+00:44:19,760 --> 00:44:23,760
+look at those documents and so on so it's again a thing that we try to help
+
+1406
+00:44:23,760 --> 00:44:30,800
+for example we produce kind of OSINT feeds of existing reports and so on to
+
+1408
+00:44:30,800 -->  00:44:36,880
+not only have software ready but to have some content and to show what kind of
+
+1411
+00:44:36,880 --> 00:44:42,559
+information can be shared within different MISP communities.
+
+1413
+00:44:42,559 --> 00:44:48,880
+So let us some get some of the naming conventions out of the way
+
+1415
+00:44:48,880 --> 00:44:52,880
+before we start with the hands-on stuff and
+
+1416
+00:44:50,400 --> 00:44:58,719
+just a quick explanation of the different uh data points and uh and naming conventions
+
+1419
+00:44:57,119 --> 00:45:00,400
+that we use for them so it's a bit easier afterwards
+
+1421
+00:45:00,400 --> 00:45:08,0
+this can be a bit overwhelming, don't worry we'll go through everything step by step also
+
+1424
+00:45:04,639 --> 
+during the hands-on part 
+
+1426
+00:45:05,519 --> 00:45:13,440
+So basically all the data that goes into MISP, we separate into two main layers
+
+1427
+00:45:11,358 --> 00:45:14,880
+one we call data layer which is really everything it has to do with
+
+1429
+00:45:14,880 --> 00:45:22,0
+individual data points their compositioning and so on
+
+1432
+00:45:20,400 --> 00:45:23,358
+So everything that we share in MISP in general in this regard
+
+1433
+00:45:22,0 --> 00:45:25,199
+2722 --> 2725.2
+starts with something that we call an event, these are our general
+
+1435
+00:45:25,199 --> 00:45:28,559
+envelopes for information so that means that
+
+1437
+00:45:28,559 --> 00:45:32,960
+whenever we're describing an incident, we're describing a threat report 
+
+1439
+00:45:32,960 --> 00:45:36,0
+2732.96 --> 2736
+we're describing a watch list that we recurringly update
+
+1441
+00:45:36,0 --> 00:45:40,400
+2736 --> 2740.4
+and they will all be grouped into something that we call an event
+
+1443
+00:45:40,400 --> 00:45:45,680
+So the name is a little bit controversial at times, we try to pick a name
+
+1445
+00:45:45,679 --> 00:45:49,519
+that is the least amount of a loaded term that we could find
+
+1448
+00:45:51,440 --> 00:45:56,240
+but obviously even with that there it can be a bit confusing but just consider
+
+1450
+00:45:56,239 --> 
+it as a generic container for data that has some contextual linking
+ 
+1453
+00:45:59,39 --> 00:46:06,318
+then each of these events is populated with lists of attributes. 
+
+1455
+00:46:05,318 --> 00:46:09,838
+So attributes are the most basic data points in MISP
+
+1457
+00:46:09,838 --> 00:46:13,279
+an attribute can describe for example an IP address
+
+1459
+00:46:13,280 --> 00:46:21,199
+you can describe a file hash or it can describe a car plate number for example
+
+1462
+00:46:21,199 --> 00:46:27,759
+It's basically just an individual data point with some basic context around it
+
+1465
+00:46:27,760 --> 00:46:30,800
+such as describing in what context this was seen in
+
+1467
+00:46:30,800 --> 00:46:32,960
+what type we're using to describe the attribute, 
+
+1469
+00:46:32,960 --> 00:46:39,679
+for example that we're using an MD5 hash to describe the hash of a file
+
+1471
+00:46:39,679 --> 00:46:44,318
+would be one of those descriptions, hopefully not used as much these days
+
+1473
+00:46:44,318 --> 00:46:51,920
+but that's just an example and then we can take these individual attributes
+
+1476
+00:46:49,599 --> 00:46:55,318
+and composite them into what we call objects that are describing multifaceted concepts.
+
+1478
+00:46:54,318 --> 00:46:59,440
+For example, a file object would be described by a list of attributes
+
+1480
+00:46:59,440 --> 00:47:05,760
+including a file name, different file hashes, maybe file entropy and so on and so forth.
+
+1484
+00:47:05,760 --> 00:47:11,440
+Each of these individual objects and attributes can then be further interlinked by what we call references.
+
+1487
+00:47:11,440 --> 00:47:15,119
+So that means that most of the time when we're describing data in MISP 
+
+1489
+00:47:15,119 --> 00:47:20,0
+we're trying to tell a story so we're thinking graphs instead of individual data points
+
+1492
+00:47:20,0 --> 00:47:24,559
+2840 --> 2844.559
+that means that we can for example, describe the entire flow of an attack
+
+1494
+00:47:24,559 --> 00:47:28,79
+from the initial attack vector all the way to the exploitation
+
+1496
+00:47:28,79 --> 00:47:33,599
+using the interconnected graphs using these references so we could say
+
+1498
+00:47:33,599 --> 00:47:36,960
+initially it all started with an email that was received
+
+1500
+00:47:36,960 --> 00:47:40,559
+that contained for example a malicious sample which then had to send this effect
+
+1503
+00:47:42,480 --> 00:47:45,838
+in our infrastructure so all of these different steps can be then described
+
+1506
+00:47:45,0 --> 00:47:53,519
+2868 --> 2873.52
+via different references there then to aggregate this information
+
+1508
+00:47:53,519 --> 00:47:58,79
+into and aggregate the sightings of this information via structure
+
+1510
+00:47:58,79 --> 00:48:02,280
+that basically captures sightings from our different information sources 
+
+1512
+00:48:01,280 --> 00:48:05,760
+that means if you have an IDS that is generating alerts
+
+1514
+00:48:05,760 --> 00:48:10,640
+you can feed information back on when individual attributes were seen
+
+1516
+00:48:10,639 --> 00:48:16,159
+in your network, in your premises or at your partners and so on
+
+1518
+00:48:16,159 --> 00:48:21,920
+so this is basically it for the data layer, these are our main building blocks for that.
+
+1521
+00:48:21,920 --> 00:48:27,599
+now in order to contextualize this information, we have different tools at our disposal.
+
+1523
+00:48:27,599 --> 00:48:32,160
+The most simple one is what we call tags these are basic text labels that 
+
+1525
+00:48:31,159 --> 00:48:35,598
+we attach on individual data points or entire events
+
+1527
+00:48:35,599 --> 00:48:39,440
+and these can either be created freely or most commonly they come from what we call taxonomies.
+
+1530
+00:48:41,519 --> 00:48:46,400
+They're basically standardized vocabularies and that are either shared
+
+1532
+00:48:46,400 --> 00:48:54,880
+by us so the MISP project at large or by individual communities to their members so
+
+1535
+00:48:53,119 --> 00:48:57,39
+these vocabularies can include anything from for example something is simple and
+
+1537
+00:48:57,39 --> 00:49:01,279
+and commonly used as TLP to national classifications 
+
+1540
+00:49:01,279 --> 00:49:08,719
+to various different sectoral classifications and so on
+
+1541
+00:49:06,318 --> 00:49:12,79
+now if you wanted to provide more high-level information instead of just simple
+
+1544
+00:49:12,559 --> 00:49:16,640
+labels for the information we can use what we call galaxy clusters
+
+1546
+00:49:16,639 --> 00:49:20,400
+so galaxy cluster is basically a knowledge based element that we use as a label
+
+1549
+00:49:21,199 --> 00:49:24,879
+these can be either coming from standard libraries 
+
+1551
+00:49:24,880 --> 00:49:28,480
+such as the ones that we maintain or you can create them ad-hoc in MISP.
+
+1553
+00:49:28,480 --> 00:49:30,0
+That means if you're describing a threat actor 
+
+1555
+00:49:30,0 --> 00:49:35,358
+you could create create a threat actor galaxy cluster that describes the various metadata
+
+1557
+00:49:35,358 --> 00:49:38,558
+about the threat actor and then use this to label your data whenever you think
+
+1560
+00:49:38,880 --> 00:49:42,160
+that whatever you're describing is associated with a threat actor
+
+1562
+00:49:42,159 --> 00:49:46,480
+you can also create for example a galaxy cluster describing the different
+
+1564
+00:49:46,480 --> 00:49:53,760
+target sectors and then interlink using cluster relationships
+
+1566
+00:49:53,760 --> 00:50:04,559
+the threat actor galaxy clusters with target sectors with exploited TTP and so on and so forth
+
+1569
+00:50:03,440 --> 00:50:07,39
+So these are the high level structures that you can put on top of your data 
+
+1572
+00:50:06,719 --> 00:50:14,838
+basically to further contextualize it. Alex
+
+1574
+00:50:15,119 --> 00:50:21,39
+Yeah, so just to summarize it and that's always a lot of people are asking about it
+
+1577
+00:50:21,199 --> 00:50:26,319
+how do you summarize it about, for example in easy way you have to see really
+
+1580
+00:50:26,318 --> 00:50:29,838
+MISP {inaudiable environment/development} as an envelope and then you
+
+1581
+00:50:28,79 --> 00:50:32,318
+have information inside and then what Andras describe is basically
+
+1583
+00:50:32,318 --> 00:50:34,800
+different component that you have within that envelope and then you have
+
+1586
+00:50:35,760 --> 00:50:42,480
+contextual layers on that envelope and relationship that are basically based on on that.
+
+1589
+00:50:42,880 --> 00:50:50,400
+So, another thing that is very often and I think it is good to explain it, is about the
+
+1592
+00:50:48,960 --> 00:50:53,119
+terminology between indicators, attributes, and so on that is
+
+1594
+00:50:53,119 --> 00:50:57,358
+a different especially indicator of compromise and so on
+
+1596
+00:50:57,358 --> 00:51:01,440
+In MISP, an attribute is close to an indicator
+
+1598
+00:51:01,440 --> 00:51:05,599
+and we have this kind of flexible models where
+
+1600
+00:51:05,599 --> 00:51:09,200
+maybe some of you are familiar with observables in MISP
+
+1602
+00:51:09,199 --> 00:51:13,440
+we call it attributes and those observables are basically depending on the type
+
+1605
+00:51:13,440 --> 00:51:20,0
+So, we have a specific flag in attributes which is basically defining
+
+1608
+00:51:20,0 --> 00:51:23,599
+3080 --> 3083.599
+if information can be used automatically for detection
+
+1610
+00:51:23,599 --> 00:51:29,960
+and that's i think one of the most important aspects when we talk about attribute in MISP
+
+1613
+00:51:28,880 --> 00:51:34,119
+an attribute can become an observable or become an indicator of compromise
+
+1615
+00:51:33,119 --> 00:51:37,880
+depending on the simple flag and this is quite important because
+
+1618
+00:51:37,280 --> 00:51:43,599
+a lot of analysis and so on will depend on that and especially all you will use that afterwards
+
+1621
+00:51:43,599 --> 00:51:48,39
+if you plan for example to use the data into a protective systems and so on 
+ 
+1624
+00:51:48,39 --> 00:51:54,79
+the IDS flags need to be set so the thing is if i take an example 
+
+1626
+00:51:54,79 --> 00:51:56,480
+you reverse the malware and this malware is connected to google.com for testing the connectivity
+
+1629
+00:51:59,519 --> 00:52:04,79
+obviously you will have an attribute for example www.google.com
+
+1632
+00:52:03,79 --> 00:52:09,440
+and this one is an interesting indicator for information for the analyst
+
+1634
+00:52:09,440 --> 00:52:14,0
+so like that you can for example maybe cluster those kind of malware together as in this kind of behavior
+
+1637
+00:52:14,0 --> 00:52:19,279
+3134 --> 3136.64
+nevertheless you are not really interested in that information as an indicator of compromise
+
+1641
+00:52:19,280 --> 00:52:23,480
+because it will generate a huge amount of false positive 
+
+1644
+00:52:23,480 --> 00:52:28,640
+but if for example at some point you have an IP address that is really dedicated to that malware 
+
+1646
+00:52:28,639 --> 00:52:39,719
+then you will set the IDS flag, so the thing is when you define in MISP these flags
+
+1649
+00:52:38,760 --> 00:52:41,599
+and we will show you later on it's very important because it will define what you can do 
+
+1652
+00:52:41,599 --> 00:52:48,639
+3164 --> 3166.64
+with information later on if you're going to automate and so on like
+
+1655
+00:52:48,159 --> 00:52:52,239
+In MISP, what we try to do too instead of having just indicators
+
+1657
+00:52:52,239 --> 00:52:57,280
+it's very common and i think many of you know about it you might see for example 
+
+1660
+00:52:57,280 --> 00:53:01,599
+a list of hashes so like for example MD5 hashes without any context
+
+1662
+00:53:01,599 --> 00:53:05,280
+and sometimes it's difficult to know exactly what we are talking about
+
+1664
+00:53:05,280 --> 00:53:11,599
+Are we talking about MD5 of malicious sample, are we talking about md5 of legitimate software,
+
+1667
+00:53:11,599 --> 00:53:17,39
+are we talking about the MD5 value of the X.509 certificate, 
+
+1669
+00:53:17,39 --> 00:53:29,719
+are we talking about an MD5 as a mutex in memory 
+
+1670
+00:53:19,679 --> 00:53:25,759
+we have plenty of way of seeing those kind of MD5 so we try in MISP to have what we call the
+
+1673
+00:53:25,759 --> 00:53:30,318
+kind of i would not say {inaudiable keep shine/kill shine} but at least contextualization a category that
+
+1675
+00:53:30,318 --> 00:53:35,279
+help to see in which context this has been seen
+
+1677
+00:53:35,280 --> 00:53:41,119
+and as for example if 1 MD5 might have a payload delivery, telling that in which scope this has been set
+
+1680
+00:53:40,559 --> 00:53:45,440
+So that means in MISP we have always and complementary type
+
+1682
+00:53:45,440 --> 00:53:52,639
+so for example for an MD5 files you can say that this one is from a file or is an md5 of a fingerprint thing
+
+1686
+00:53:52,639 --> 00:53:59,679
+So that means, always in MISP try to have as an indicator all those three information together 
+
+1689
+00:53:59,679 --> 00:54:06,639
+so it is giving at least more context and if you cannot set this context MISP will try to automatically set it.
+
+1692
+00:54:05,639 --> 00:54:12,239
+So attributes are equal to indicators but with a bit more of information which is useful for you
+
+1695
+00:54:12,239 --> 00:54:19,358
+At least being in a way to understand what is in a position to understand what you have in front of you
+
+1699
+00:54:19,358 --> 00:54:28,400
+when you have to treat those attributes.
+
+1700
+00:54:25,358 --> 00:54:29,920
+So this is just a brief view of what this looks like. 
+
+1702
+00:54:29,920 --> 00:54:36,239
+We're going to see this more in practice basically the idea is that all the data that we have in  MISP
+
+1705
+00:54:36,239 --> 00:54:43,798
+if it's well defined allows us to draw a graph out of the data and allows us to tell a story more easily
+
+1708
+00:54:42,880 --> 00:54:55,798
+So here we see a simple example that basically shows the bank account that is associated with the threat actor
+
+1712
+00:54:54,480 --> 00:55:00,679
+With all the various different data points with it and then we can basically relate these
+
+1715
+00:54:59,280 --> 00:55:03,200
+different data points to each other and give the relationship a term as well 
+
+1718
+00:55:04,880 --> 00:55:08,160
+So in this case we see from the chart immediately there that that person is the owner of that
+
+1720
+00:55:08,159 --> 00:55:13,119
+bank account with all those different data points for us as humans it's it's generally much more
+
+1724
+00:55:13,119 --> 00:55:18,839
+easily understood if we look at a graph like that and tell the story that way 
+
+1727
+00:55:17,839 --> 00:55:22,480
+then if we look at a tabularized view of the data.
+
+1728
+00:55:20,798 --> 00:55:24,239
+So one of the goals and something that we hope that we get out of 
+ 
+1731
+00:55:24,239 --> 00:55:32,480
+going through trainings like these is to really convert also the participants
+
+1732
+00:55:29,679 --> 00:55:38,558
+to to see the value of producing data in that way instead of just sharing raw indicator lists for example.
+
+1735
+00:55:40,0 --> 00:55:45,199
+3340 --> 3343.2
+And that's again what we think that's really important is the contextualization again.
+
+1738
+00:55:45,280 --> 00:55:50,480
+So i mentioned we have the galaxies in MISP and we have plenty of representation
+
+1741
+00:55:50,318 --> 00:55:55,838
+threat actors and so on and obviously one that is quite important is the MITRE Attack one
+
+1744
+00:55:54,719 --> 00:55:57,759
+so MITRE Attack is {inaduiable stored/performed} as a galaxy
+
+1746
+00:55:57,760 --> 00:56:01,520
+and we have this flexible {inaduiable mosaic/table} in MISP that you can represent those kind of
+
+748
+00:56:01,519 --> 00:56:07,39
+matrix-like model which is a case for Attack which is a very convenient way of representing the 
+
+1752
+00:56:07,679 --> 00:56:14,480
+different techniques in a progressive way used by the attackers and that's exactly what we can do in MISP. 
+
+1755
+00:56:14,159 --> 00:56:22,79
+So you have this kind of model and we have different model formats so again we have an advanced
+
+1758
+00:56:22,79 --> 00:56:30,838
+i would say integration with Attack but you can extend it with multiple different kinds of galaxies which are
+
+1762
+00:56:30,0 --> 00:56:33,838
+3390 --> 3393.839
+similar to Attack or complementary for example we have the Industrial Control System of Attack,
+
+1765
+00:56:34,400 --> 00:56:39,440
+it's a separated galaxy, you can even create a custom one directly in the system 
+
+1768
+00:56:39,440 --> 00:56:46,519
+and then you can filter out your data and so on and that's exactly the thing why we are i would say
+
+1771
+00:56:46,880 --> 00:56:51,480 
+in bracket pushing people to do more contextualization, it would be useful forthem at the end
+
+1774
+00:56:51,599 --> 00:56:58,960
+because this kind of information is really showing you for example your gap in your defense
+
+1778
+00:56:58,960 --> 00:57:02,720
+your specific things that the techniques that are not used by an attacker 
+
+1780
+00:57:02,719 --> 00:57:05,279
+you might ask why, maybe because you are missing a specific detection point that you cannot
+
+1783
+00:57:05,279 --> 00:57:12,239
+detect this kind of attacks or things like that so it's really actively using the data
+
+1786
+00:57:12,239 --> 00:57:15,759
+to show something meaningful with it and i think Attack is one of the way
+
+1788
+00:57:15,760 --> 00:57:19,119 
+but if you can combine this with additional information like site links, 
+
+1789
+00:57:19,119 --> 00:57:22,239
+contextualization of the relationship between different objects and so on
+
+1792
+00:57:22,239 --> 00:57:26,558
+basically everything in hand to improve your posture and secure it.
+
+1794
+00:57:26,559 --> 00:57:29,0
+Yeah perhaps something to add to this as well,
+
+1796
+00:57:29,0 --> 00:57:33,838
+some of the additional advantages is the moment that you encode all this information along
+
+1798
+00:57:33,838 --> 00:57:39,39
+with the data you can start asking those those questions from your tool basically
+
+1800
+00:57:39,39 --> 00:57:47,838
+for example show me what sort of threats my constituency is facing over the past year
+
+1804
+00:57:45,760 --> 00:57:49,760
+and overlayed over how what sort of threats it was facing a year ago 
+
+1806
+00:57:49,760 --> 00:57:52,319
+what are the trends that have evolved since then
+
+1808
+00:57:52,318 --> 00:57:58,960
+the other thing that it really helps with is it also gives you a high level overview of individual reports
+
+1811
+00:57:56,400 --> 00:58:06,78
+that means if I'm looking at an event in MISP and it has 800 different attributes described in there
+
+1815
+00:58:06,79 --> 00:58:10,719
+making any sense out of that quickly is very difficult, but getting a high level overview using MITRE Attack
+
+1818
+00:58:10,719 --> 00:58:16,239
+where you say oh okay this has to deal with spearphishing, it has to deal with information exfiltration,
+
+1821
+00:58:16,239 --> 00:58:22,79
+so these immediately tell me the story of what i'm dealing with without having to dig deeper into the data itself
+
+1825
+00:58:22,79 --> 00:58:27,480
+so it is incredibly useful for an analyst that is trying to make sense of the data that you're sharing.
+
+1828
+00:58:27,480 --> 00:58:36,0
+Also, as for the sharing itself i mean one of the main goals with MISP is obviously to share information,
+
+1831
+00:58:36,0 --> 00:58:43,280
+We haven't really talked about the sharing mechanisms yet, we basically have a bunch of different functionalities in MISP
+
+1834
+00:58:42,880 --> 00:58:48,639
+that we're going to see over the next two days the deal with distributing the information.
+
+1838
+00:58:48,639 --> 00:58:55,280
+One of the most obvious ones to tackle is basically who is to be the recipient of information that we're sharing
+
+1842
+00:58:55,280 --> 00:59:04,400
+so basically MISP, we can basically set the distribution settings for each individual data point individually
+
+1846
+00:59:04,400 --> 00:59:10,760
+or for entire collections of data in one shot so that means if we create an event we can decide who we share the event with 
+
+1849
+00:59:09,760 --> 00:59:15,160
+but we can further restrict individual attributes or objects further. 
+
+1854
+00:59:14,838 --> 00:59:26,79
+Now, who we share the information with gets decided on using one of two different means,
+
+1857
+00:59:25,79 --> 00:59:29,39
+one of them is a simple system where we tell MISP you are allowed to distribute it to everyone 
+
+1858
+00:59:28,440 --> 00:59:31,280
+that has access to this community, for example.
+
+1860
+00:59:31,280 --> 00:59:39,440
+Or to everyone that is directly connected to my community but you can also define more strict distribution lists
+
+1863
+00:59:37,838 --> 00:59:44,400
+what we call sharing groups where you individually name the organizations that are to be the recipients.
+
+1868
+00:59:44,400 --> 00:59:52,159
+Now on top of that, one of the things that we often struggle with is especially if you're in some of those communities
+
+1872
+00:59:51,159 --> 01:00:01,39
+or you're taking part or assisting some of the communities where sharing any information might lead to reputation or financial loss.
+
+1876
+01:00:01,39 --> 01:00:04,318
+For example in the financial sector we have these worries very often
+
+1878
+01:00:04,318 --> 01:00:08,318
+where if a financial organization were to share any information out
+
+1880
+01:00:08,318 --> 01:00:11,838
+it could be misconstrued as a successful attack against them.
+
+1882
+01:00:11,838 --> 01:00:15,719
+So instead, they choose to basically even if it was something completely benign
+
+1884
+01:00:14,719 --> 01:00:20,239
+that they caught in their sandboxes, in their honeypots, whatever
+
+1887
+01:00:19,199 --> 01:00:24,399
+and they decide not to share it out of fear of incurring this reputation loss.
+
+1889
+01:00:24,399 --> 01:00:29,440
+So one of the things that we have in MISP is this system called Delegation 
+
+1891
+01:00:29,440 --> 01:00:31,920
+where you can, for example appoint your ISAC,
+ 
+1892
+01:00:29,679 --> 01:00:38,558
+your central authority for a community, a national CSIRT, whatever 
+
+1893
+01:00:38,558 --> 01:00:41,599
+with the responsibility of taking over the data that you produce
+
+1898
+01:00:41,599 --> 01:00:43,480
+and to share it out in their name  
+
+1900
+01:00:43,480 --> 01:00:48,838
+so that way, it's basically a semi anonymized information sharing 
+
+1901
+01:00:48,559 --> 01:00:50,880
+where you are completely removed from the data that is shared out
+
+1903
+01:00:50,880 --> 01:00:55,500
+so the only two parties that will know who the originator of the data is you
+
+1904
+01:00:55,500 --> 01:01:01,500
+and whoever is taking over the data and taking over responsibility for the data.
+
+1909
+01:01:02,0 --> 01:01:05,280
+On top of that, one of the things that we wanted to achieve with MISP 
+
+1911
+01:01:05,280 --> 01:01:08,720
+was basically to build a collaboration with our different partners
+
+1913
+01:01:08,719 --> 01:01:11,519
+so it means that whenever we're sharing information we don't want it to
+
+1915
+01:01:11,519 --> 01:01:14,358
+be a one-way communication, so we don't want to have 
+
+1916
+01:01:13,358 --> 01:01:17,500
+this whole feed, provider and consumers relationship 
+
+1919
+01:01:17,500 --> 01:01:20,798
+but we want everyone to be able to chip in with their ideas
+
+1920
+01:01:20,798 --> 01:01:24,559
+so while anything that you produce in MISP will only be tied and editable
+
+1921
+01:01:24,559 --> 01:01:28,719
+by your organization, others can make proposals or counter analysis to it.
+
+1924
+01:01:28,719 --> 01:01:32,919
+So proposals are a system where you can basically flag information
+
+1926
+01:01:32,919 --> 01:01:37,0
+as incorrect and provide feedback on how to improve it 
+
+1928
+01:01:37,0 --> 01:01:40,0
+or how you can add your own perspective to an event,
+
+1930
+01:01:40,0 --> 01:01:42,0
+so if you receive an event from a third party you can say 
+
+1931
+01:01:42,0 --> 01:01:44,400
+oh i can improve it and {inaudiable listen/discern} this way
+
+1932
+01:01:44,400 --> 01:01:46,8
+please incorporate these changes in the event
+
+1933
+01:01:46,318 --> 01:01:49,500
+and then the original producer can make the decision 
+
+1935
+01:01:48,500 --> 01:01:51,519
+whether to incorporate it or discard your changes.
+
+1936
+01:01:51,519 --> 01:01:55,358
+As for counter analysis, this is what we call extend events.
+
+1938
+01:01:55,358 --> 01:01:59,358
+You can basically create an event that latches onto an original 
+
+1940
+01:01:59,358 --> 01:02:03,38
+shared by a third party and provide your own perspective of it.
+
+1942
+01:02:03,0 --> 01:02:06,160
+and then you keep full control of the data and you become the owner
+
+1945
+01:02:06,160 --> 01:02:09,440
+of whatever the extension is that you produce to the original event.
+
+1946
+01:02:09,440 --> 01:02:17,280
+This happens very often for us, for example when a vendor shares out a report.
+
+1949
+01:02:17,280 --> 01:02:21,0
+For example, we get a report from say kaspersky and we have additional information 
+
+1951
+01:02:20,0 --> 01:02:25,519
+or we have a different opinion on something, 
+
+1954
+01:02:25,519 --> 01:02:29,960
+then we might create an extended event that we share out to our constituency 
+
+1957
+01:02:28,960 --> 01:02:33,358
+which if they have access to the original report will latch onto it
+
+1958
+01:02:33,358 --> 01:02:37,0
+and it will show our perspective on top of the original.
+
+1960
+01:02:37,519 --> 01:02:41,440
+Now as for the exchange itself, every organization is free to host their own
+
+1962
+01:02:41,440 --> 01:02:44,960
+MISP instance and then they can decide who they want to interconnect with
+
+1964
+01:02:44,960 --> 01:02:48,240
+if both parties agree, a synchronization link is established
+
+1966
+01:02:48,239 --> 01:02:51,838
+between the two MISP instance and sharing can start flowing between them.
+
+1968
+01:02:51,838 --> 01:02:55,0
+Now this sharing is still governed by those distribution lists 
+
+1970
+01:02:54,500 --> 01:02:59,199
+and by some other mechanism that we'll talk about more tomorrow 
+
+1972
+01:02:59,199 --> 01:03:04,0
+but basically MISP exchanges information between the individual nodes
+
+1974
+01:03:02,798 --> 01:03:06,880
+in kind of a mesh network way.
+
+1976
+01:03:06,880 --> 01:03:10,0
+We also have feed system that allows us to generate feeds
+
+1977
+01:03:10,0 --> 01:03:11,960
+and to share those feeds with larger communities.
+
+1979
+01:03:11,960 --> 01:03:15,559
+So we as CIRCL we provide another SIEM feed, for example
+
+1980
+01:03:15,280 --> 01:03:20,0
+that we make freely available in our infrastructure
+
+1981
+01:03:20,0 --> 01:03:22,440
+anyone can just point their MISP to it and adjust the data
+
+1983
+01:03:22,440 --> 01:03:26,119
+and keep it updated using the feed system, this is also great
+
+1985
+01:03:26,119 --> 01:03:30,0
+if you have ever have the need of sharing information between air gap systems.
+
+1986
+01:03:29,559 --> 01:03:37,0
+You can just generate a feed based on certain filter rules and basically
+
+1989
+01:03:37,0 --> 01:03:43,0
+share it through say a flash drive or something like that, with an internal system
+
+1993
+01:03:44,0 --> 01:03:48,720
+Now all of these filtering options are basically user defined
+
+1994
+01:03:48,0 --> 01:03:50,880
+and they rely heavily also on the contextualization  
+
+1997
+01:03:50,880 --> 01:03:54,0
+so very often what we're doing and especially
+
+1998
+01:03:53,639 --> 01:03:57,0
+if you were ever signing up for the COVID instance that i mentioned before
+
+2000
+01:03:57,0 --> 01:04:00,559
+is you can also make those decisions based on the context, 
+
+2002
+01:04:00,559 --> 01:04:02,960
+what data you're interested in, what date you're interested in sharing out.
+
+2004
+01:04:02,960 --> 01:04:06,400
+For example, if you connect to COVID instance, we categorize all of the
+
+2006
+01:04:06,400 --> 01:04:10,79
+information into three categories, health related information
+
+2008
+01:04:9,79 --> 01:04:12,720
+so basically information about the spread of the pandemic,
+
+2010
+01:04:12,719 --> 01:04:16,399
+information about misinformation targeting COVID,
+
+2012
+01:04:16,400 --> 01:04:22,0
+and also cyber security threats that are targeting, that are now basically 
+
+2014
+01:04:21,0 --> 01:04:27,0
+abusing the whole COVID situation with remote work and so on.
+
+2016
+01:04:27,0 --> 01:04:30,0
+so if you're only interested in one or two of these three different topics,
+
+2019
+01:04:30,0 --> 01:04:36,0
+then you can set up your filters to only ingest data coming from a subset of the data set
+
+2021
+01:04:36,0 --> 01:04:39,0
+Very often what we do as well is we have these internal MISP clusters
+
+2023
+01:04:38,480 --> 01:04:44,0 
+in our own organization as well, where we collect information from different sources
+
+2026
+01:04:43,798 --> 01:04:48,798
+so we have a dedicated MISP instance where we purely collect spam information for example
+
+2029
+01:04:48,798 --> 01:04:52,0
+So for a constituency, anyone can forward their spam to us
+
+2031
+01:04:52,0 --> 01:04:55,358
+and we'll just generate events out of those in that MISP. 
+
+2032
+01:04:55,358 --> 01:04:56,38
+Generally this information 
+
+2033
+01:04:56,38 --> 01:05:00,480
+is really not interesting for a day-to-day detection use, for example.
+
+2036
+01:05:00,480 --> 01:05:03,679
+But what we do is we cache this information and we can cross-correlate
+
+2038
+01:05:03,679 --> 01:05:05,759
+this information with our operational instance
+
+2040
+01:05:05,760 --> 01:05:11,839
+that means if we start the analysis process and we start an investigation
+
+2042
+01:05:11,839 --> 01:05:14,239
+then we immediately see the moment we start encoding data points
+
+2044
+01:05:14,239 --> 01:05:18,598
+oh this is something that was already flagged once in our spam instance
+
+2046
+01:05:18,598 --> 01:05:210,359
+this information that that instance knows about, 
+
+2048
+01:05:210,359 --> 01:05:24,840
+then we can pivot over to that instance and fetch the information
+
+2049
+01:05:24,840 --> 01:05:28,400
+related to that same data point that we're also seeing in our current incident
+
+2052
+01:05:28,400 --> 01:05:32,0
+and perhaps get more information that is relevant for us from there.
+
+2054
+01:05:32,0 --> 01:05:35,79
+3932 --> 3936.079
+So basically very often we have these multi MISP internal enclaves
+
+2057
+01:05:35,79 --> 01:05:42,0
+that help us basically to separate different concerns and
+
+2058
+01:05:41,0 --> 01:05:44,0
+different collection mechanisms into their own instances.
+
+2060
+01:05:45,440 --> 01:05:49,39
+Just in that scope and I think is linked to the question that we had
+
+2062
+01:05:49,39 --> 01:05:52,799
+regarding the multi MISP internal enclave
+
+2064
+01:05:52,798 --> 01:05:57,599
+someone was asking about synchronizing with an existing MISP and so.
+
+2066
+01:05:57,599 --> 01:06:00,720
+You have this kind of local enclave options, where you can synchronize to MISP
+
+2068
+01:06:00,719 --> 01:06:05,199
+like they behave in the same organization, that's one of the interesting options.
+
+2071
+01:06:05,199 --> 01:06:09,358
+By the way, I would just give the mic to Josh that will explain a bit more about 
+
+2074
+01:06:09,358 --> 01:06:16,0
+the question and answer in zoom, to have directly the ability to answer the question answering the Zoom {inaudiable}
+
+2077
+01:06:18,400 --> 01:06:20,639
+I just want to jump in real quick, yeah if you have any questions 
+
+2080
+01:06:20,639 --> 01:06:26,400
+please direct them at the Q&A board versus the chat room 
+
+2081
+01:06:26,400 --> 01:06:28,0
+that way we can kind of keep a monitor of that 
+
+2082
+01:06:28,0 --> 01:06:32,0
+and other people can actually see the questions and the answer directly in that area
+
+2085
+01:06:32,0 --> 01:06:38,0
+so if you have questions feel free to use the Q&A board and that's all 
+
+2086
+01:06:38,0 --> 01:06:43,199
+thank you josh that's very useful so we can keep track of them and we can answer live or
+
+2090
+01:06:43,199 --> 01:06:44,700
+directly in the chat. 
+
+2091
+01:06:44,700 --> 01:06:49,520
+Okay great, so you see that the sharing aspect of MISP is like pretty extensive
+
+2094
+01:06:49,520 --> 01:06:53,279
+and you have different models of of usage of MISP 
+
+2097
+01:06:53,279 --> 01:06:58,318
+some people have this pre-conception about MISP being like oh I need to share with MISP 
+
+2099
+01:06:58,318 --> 01:07:01,119
+no, it's depending on what you want to do with your MISP instance
+
+2101
+01:07:01,119 --> 01:07:05,500
+and the core functionality of MISP is really to give, I would say the freedom 
+
+2104
+01:07:05,500 --> 01:07:11,0
+to each of the organizations to decide what to do with the data, if they want to share or not
+
+2106
+01:07:11,0 --> 01:07:17,359
+and we always design MISP that everyone can be kind of consumers
+ 
+2109
+01:07:17,359 --> 01:07:21,838
+so that basically getting data from different fields or producer or contributors
+
+2110
+01:07:21,838 --> 01:07:29,0
+Andras mentioned a different way of contributing like sightings, making proposals, things like that
+
+2114
+01:07:29,0 --> 01:07:34,240
+but it's up to the original contributors to decide if they want to share 
+
+2117
+01:07:34,240 --> 01:07:41,119
+that's really the thing, with MISP you can set up a MISP for like just pulling data, getting the data and that's it
+
+2120
+01:07:41,119 --> 01:07:46,480
+and if at one point in time you want to like push some data you can just enable it and that's it 
+
+2123
+01:07:46,480 --> 01:07:51,0
+so it's really, it's just a matter of just tuning the configuration ,
+
+2126
+01:07:51,0 --> 01:07:53,0
+the filtering really on the synchronization, if you want to share.
+
+2128
+01:07:53,0 --> 01:07:55,838
+So you don't have to change anything in your MISP instance
+
+2129
+01:07:55,838 --> 01:07:59,0
+it's just a matter of of what you decide and what you need to share
+
+2132
+01:07:59,0 --> 01:08:01,500
+and then the thing that is really important in MISP
+
+2133
+01:08:01,500 --> 01:08:05,760
+everything can be in flex. I mean even for example that we were mentioning 
+
+2135
+01:08:05,760 --> 01:08:10,240
+so those kind of envelope information might change over time
+
+2137
+01:08:10,239 --> 01:08:15,0
+we have seen for example some past or incident report that has been updated like 
+
+2140
+01:08:15,0 --> 01:08:19,0
+two years later because they discover who was the target or the threat actor behind
+
+2142
+01:08:19,0 --> 01:08:24,0
+and that's the thing that's really in MISP that we really want to be flexible 
+
+2145
+01:08:24,0 --> 01:08:29,500
+you can really expand the information either internally, add some comment and so on
+
+2147
+01:08:29,500 --> 01:08:35,359
+and to share this information in your different MISP instances and share with partners,
+
+2150
+01:08:35,359 --> 01:08:37,200
+your teams and so on so. 
+
+2151
+01:08:37,200 --> 01:08:42,0
+Really, MISP the core functionality of MISP is distributing information 
+
+2153
+01:08:42,0 --> 01:08:46,500
+but if you don't want to use it it's fine you just don't enable synchronization 
+
+2156
+01:08:46,500 --> 01:08:50,0
+but if you want to use partially, part of synchronization and so on 
+
+2158
+01:08:50,0 --> 01:08:53,838
+you just set up this kind of parameters. 
+
+2160
+01:08:55,0 --> 01:09:00,0
+So on top of collecting all this information
+
+2161
+01:09:00,0 --> 01:09:03,0
+and synchronizing the information that we talked about before
+
+2162
+01:09:03,0 --> 01:09:06,0
+we basically do a bunch of different stuff to improve 
+
+2164
+01:09:06,0 --> 01:09:08,0
+to handle the quality management of the information as well.
+
+2165
+01:09:08,0 --> 01:09:11,0
+So one of the first things we do, this is something we mentioned a bit before
+
+2167
+01:09:11,0 --> 01:09:16,0
+is we correlate information so we're interested in data that we've already seen before
+
+2170
+01:09:16,0 --> 01:09:18,559
+we also have the feedback loop that we mentioned before with sightings 
+
+2172
+01:09:18,560 --> 01:09:22,0
+that means we really want to get timeliness to the information as well
+
+2175
+01:09:22,0 --> 01:09:27,439
+so that we can but make better decisions on what we keep in our working data set for detection,
+
+2177
+01:09:27,439 --> 01:09:29,5
+for blocking and so on.
+
+2178
+01:09:29,520 --> 01:09:33,679
+The false positive management is a huge part so the warning list system
+
+2180
+01:09:33,679 --> 01:09:37,0
+where we basically exclude those typical false positives
+
+2182
+01:09:37,0 --> 01:09:41,440
+plays a very important role in the legal equation and this is also a community driven effort
+
+2184
+01:09:41,439 --> 01:09:46,0
+so if you want to get involved with that and build and include your own infrastructure 
+
+2187
+01:09:46,0 --> 01:09:48,399
+for example in the warning list and so on,
+
+2189
+01:09:48,399 --> 01:09:53,0
+either do it internally for your MISP or just share it with the open source community as well
+
+2191
+01:09:53,0 --> 01:09:56,719
+so let us know if you want to have that included as well 
+
+2193
+01:09:56,719 --> 01:09:58,500
+we haven't talked about enrichment systems yet 
+
+2195
+01:09:58,500 --> 01:10:00,880
+but basically one of the things that we do in MISP is 
+
+2196
+01:10:00,880 --> 01:10:05,238 
+we have connectors to all those different services that you might already be subscribed to
+
+2199
+01:10:05,238  --> 01:10:11,439
+so if you have domain tools, passive total or what way or any of the other services
+
+2202
+01:10:11,439 --> 01:10:15,439
+intel 471, and so on that you already subscribed to, then you can use  
+
+2205
+01:10:15,439 --> 01:10:19,600
+those services to enrich the data that you're working on 
+
+2208
+01:10:19,600 --> 01:10:22,0
+so if you have an incident and you're encoding information 
+
+2209
+01:10:22,0 --> 01:10:24,640
+you go out to all the services that you connect, that you have access to
+
+2210
+01:10:24,640 --> 01:10:29,600
+4224.64 --> 4228
+and fetch the information on what else those systems know about the different data points that you're encoding
+
+2213
+01:10:29,600 --> 01:10:33,679
+so that you basically get a jump start on your investigation.
+
+2215
+01:10:33,679 --> 01:10:37,119
+Now one of the most important things that we have to deal with and this is probably 
+
+2217
+01:10:37,119 --> 01:10:42,559
+i think about 50% of the code base of MISP 
+
+2219
+01:10:42,560 --> 01:10:46,560
+is basically the APIs and the libraries that deal with integrating MISP with other tools
+
+2221
+01:10:46,560 --> 01:10:50,580
+so everything that we can do by the UI, MISP is also exposed to the api
+
+2223
+01:10:50,580 --> 01:10:54,960
+and one of the most important things for us is to make sure that
+
+2225
+01:10:54,960 --> 01:11:00,0
+you can use MISP as simply a backend for another tool as opposed to just directly using MISP itself.
+
+2228
+01:11:00,0 --> 01:11:04,640
+As for timeliness, we haven't really touched on that yet.
+
+2230
+01:11:04,640 --> 01:11:10,480
+Besides the sighting aspect, you can also encode information about time ranges when something was seen
+
+2233
+01:11:10,480 --> 01:11:19,200
+and you can build a full timeline of the events that occurred during a cyber incident for example.
+
+2237
+01:11:19,200 --> 01:11:22,719
+So if you encode this information together with all your data points
+
+2239
+01:11:22,719 --> 01:11:26,960
+then you get an additional graph out of it that tells you when what happens
+
+2241
+01:11:26,960 --> 01:11:30,0
+and time-based correlations are really important as well.
+
+2243
+01:11:30,0 --> 01:11:33,599
+So very often when you're seeing two things happening at the same time
+
+2245
+01:11:33,600 --> 01:11:35,800
+they might be related with each other and 
+
+2248
+01:11:35,800 --> 01:11:40,960
+they might be worth digging into whether there is a link between those two things that happened.
+
+2250
+01:11:40,960 --> 01:11:43,480
+So something else that we will touch on more tomorrow 
+
+2251
+01:11:43,480 --> 01:11:47,200
+is we have a full indicator lifecycle management system in MISP.
+
+2254
+01:11:47,200 --> 01:11:50,0
+That means you can define your own rules and tune your own rules 
+
+2256
+01:11:50,0 --> 01:11:53,500
+on how you're going to be scoring and decaying indicators 
+
+2257
+01:11:53,500 --> 01:11:57,119
+based on all the contextualization that you have,
+
+2258
+01:11:57,119 --> 01:11:58,719
+based on the type of the data that you have, 
+
+2259
+01:11:58,719 --> 01:12:02,439
+based on source of the information that you have and so on and so forth.
+
+2260
+01:12:02,439 --> 01:12:09,0
+So we're going to go into much more detail on that tomorrow. Alex.
+
+2265
+01:12:15,359 --> 01:12:20,359
+Yeah, so I was just answering a question and then I will make it public in a minute
+
+2267
+01:12:20,359 --> 01:12:25,639
+that's a question about the API and using MISP. 
+
+2270
+01:12:25,639 --> 01:12:30,0
+There are different ways to evaluate the quality of the information that you share in MISP.
+
+2273
+01:12:30,0 --> 01:12:35,238
+One of those is obviously to look at statistics, There is a statistics version in MISP to see 
+
+2276
+01:12:35,238 --> 01:12:40,238
+for example, the kind of indicator shared by organization and so on.
+
+2278
+01:12:40,238 --> 01:12:43,279
+In addition to that, there is for example 
+
+2279
+01:12:43,279 --> 01:12:46,279
+MISP dashboard which includes a kind of gamification of the platforms
+
+2281
+01:12:46,279 --> 01:12:53,600
+and which is giving badges per organization depending on the kind of information that you share
+
+2284
+01:12:53,600 --> 01:12:59,520
+and that's a nice way to to find out if you are reaching a certain level of capabilities when using MISP
+
+2287
+01:12:59,520 --> 01:13:02,360
+where you basically have for example information like
+
+2289
+01:13:02,360 --> 01:13:08,960
+are you using sightings, do you use objects and stuff like that. 
+
+2292
+01:13:08,960 --> 01:13:12,0
+For example, thing that you can really look at if you want to see 
+
+2293
+01:13:12,0 --> 01:13:14,480
+if the quality of information that you create in MISP
+
+2296
+01:13:14,480 --> 01:13:19,560
+i would just following the standards what is following the best practices in the different organization
+
+2297
+01:13:19,560 --> 01:13:22,640
+is to compare with the {inaudiable} feed 
+
+2300
+01:13:22,640 --> 01:13:25,198
+there are some goods even in the OSINT feed and 
+
+2301
+01:13:25,198 --> 01:13:29,519
+for example, things that are really a good indicator is to see
+
+2303
+01:13:29,520 --> 01:13:32,880
+are you just using indicators and using objects, 
+
+2305
+01:13:32,880 --> 01:13:35,0
+are those objects linked together by using the relationship to it,
+
+2306
+01:13:35,0 --> 01:13:40,199
+are you using galaxies, are those galaxies at the event level, {inaudiable} level,
+
+2308
+01:13:40,198 --> 01:13:46,0
+do you have tags,  labels on specific objects or specific attributes and so on
+
+2311
+01:13:46,0 --> 01:13:52,960
+that's different parameters and i think the question from {inaudiable} is pretty good.
+
+2315
+01:13:52,960 --> 01:14:00,39
+and if you really want to dive into the KPI aspect of MISP and quality of information.
+
+2316
+01:14:00,39 --> 01:14:03,239
+In addition to what Andras just said 
+
+2320
+01:14:03,239 --> 01:14:07,600
+there are some other things about the quality of information shared within the community
+
+2321
+01:14:07,600 --> 01:14:11,920
+and there's some good examples in the MISP dashboard about the different badges
+
+2324
+01:14:11,920 --> 01:14:16,0
+there is even a model for sharing such kind of information.
+
+2326
+01:14:16,0 --> 01:14:19,0
+So another thing that is i think quite useful and 
+
+2329
+01:14:19,0 --> 01:14:23,520
+it was one of the core functionality of MISP was the correlation features.
+
+2330
+01:14:23,520 --> 01:14:29,119
+This one is, it looks like obvious but it's not always obvious 
+
+2332
+01:14:29,119 --> 01:14:32,800
+I mean a lot of tools in the security field exist but they don't do automatic correlations.
+
+2334
+01:14:32,800 --> 01:14:35,679
+For example, at the {inaudiable} we are using ticketing system  
+
+2337
+01:14:37,119 --> 01:14:39,0
+and sometimes it's very difficult to find if we have two correlating events 
+
+2338
+01:14:39,0 --> 01:14:42,820
+and what we decided in MISP which covers the cost. 
+
+2339
+01:14:42,820 --> 01:14:48,800
+I mean the correlation engine is maybe one of the costly aspects of using MISP on a database level.
+
+2341
+01:14:48,800 --> 01:14:49,919
+but it's really useful.
+
+2342
+01:14:49,919 --> 01:14:52,500
+For example, here we just have an example of 
+
+2343
+01:14:52,500 --> 01:15:00,500
+information about some malware spam that are used to share uh information about
+
+2348
+01:15:00,500 --> 01:15:04,239
+target campaigns for the financial malware
+
+2351
+01:15:04,239 --> 01:15:09,819
+and what we can see there is basically correlation on similar points
+
+2352
+01:15:09,819 --> 01:15:12,880
+and those ones are mainly IP addresses of the infrastructure
+
+2355
+01:15:12,880 --> 01:15:16,0
+but you can really spot interesting things there.
+
+2357
+01:15:16,0 --> 01:15:19,679
+For example, you see that the third {inaudiable bone/bin} in Germany share indicators,
+
+2360
+01:15:19,679 --> 01:15:24,0
+you have a polish bank sharing the same kind of indicators 
+
+2361
+01:15:24,0 --> 01:15:26,560
+we were sharing such kind of indicators too
+
+2362
+01:15:26,560 --> 01:15:30,640
+and even if they have different names or different contextualization 
+
+2365
+01:15:30,640 --> 01:15:33,439
+we can really spot similar infrastructure 
+
+2366
+01:15:33,439 --> 01:15:39,198
+so we can see okay, it's maybe the same actors using an infrastructure for different kind of things
+
+2369
+01:15:39,198 --> 01:15:45,679
+or for example we can actually see here that we have different names of the similar malware 
+
+2372
+01:15:45,679 --> 01:15:48,0
+so really this is important for example another thing that is interesting is
+
+2374
+01:15:48,0 --> 01:15:53,739
+for example if you have a sinkhole IP address setup by a antivirus company for example, 
+
+2377
+01:15:53,739 --> 01:15:57,560
+you can directly spot it. I mean if you have, I don't know, APT 29 
+
+2380
+01:15:57,560 --> 01:16:01,840
+and you have like three different criminals malware going on that one and so on 
+
+2383
+01:16:01,840 --> 01:16:05,600
+obviously it's usually not the same infrastructures but on the other hand 
+
+2385
+01:16:05,600 --> 01:16:08,39
+you can directly spot, okay this one is already take down 
+
+2386
+01:16:08,39 --> 01:16:12,159
+it's handled by this antivirus company and you can really handle it
+
+2388
+01:16:12,158 --> 01:16:20,679
+so it's really a way to quickly find if it's a new threat or something that is already known in the infrastructure
+
+2392
+01:16:22,439 --> 01:16:28,640
+So a little bit of the sightings themselves so we're going to see this more in practice
+
+2395
+01:16:28,640 --> 01:16:36,79
+basically we have a very simple interfacing list that allows us to to tell the community
+
+2398
+01:16:36,79 --> 01:16:40,158
+that we've seen an indicator, as well as when we've seen it
+
+2401
+01:16:40,158 --> 01:16:46,238
+and perhaps also include information on what tool we've picked up, what context we've seen,
+
+2402
+01:16:46,238 --> 01:16:50,359
+so sightings can have some metadata on top of just being a sighting. 
+
+2406
+01:16:50,359 --> 01:16:54,79
+We can also flag something that we call negative sightings which is a false positive sighting
+
+2409
+01:16:54,79 --> 01:16:59,0
+where we indicate that we've seen it but it produced issues for us so it was a false positive.
+
+2412
+01:16:59,0 --> 01:17:05,520
+We can also indicate that something is potentially going to be expired at a certain date,
+
+2415
+01:17:05,520 --> 01:17:10,0
+so this is interesting, for example, if we're in talks with a provider 
+
+2418
+01:17:10,0 --> 01:17:11,519
+and we know that there is going to be a takedown 
+
+2420
+01:17:11,519 --> 01:17:17,0
+then we can already indicate that okay, this is no longer an indicator after a certain point in time.
+
+2422
+01:17:17,0 --> 01:17:21,679
+Apart from that if you are ever dealing with bulk sightings,
+
+2424
+01:17:21,679 --> 01:17:28,0
+so if you want to for example just capture any IP address seen in your network or something like that
+
+2427
+01:17:28,0 --> 01:17:34,560
+there is another tool called SightingDB, which is developed by Devo, it's also an open source tool.
+
+2430
+01:17:34,560 --> 01:17:38,79
+It's really recommended to use that, it allows you to to capture massive massive amounts of data
+
+2432
+01:17:38,79 --> 01:17:45,539
+so if you're capturing the entire network flow of your constituency and or your organization 
+
+2436
+01:17:45,539 --> 01:17:49,920
+and just dumping all the data somewhere this is a great place to do it
+
+2439
+01:17:49,920 --> 01:17:53,760
+and it's a very fast lookup database that is integrated with MISP
+
+2441
+01:17:53,760 --> 01:17:58,500
+where MISP can automatically just query it for any of the indicators that you're seeing in MISP,
+
+2445
+01:17:58,500 --> 01:18:05,359
+and whether it was seen in your network, and in which time range it was seen in.
+
+2446
+01:18:03,0 --> 01:18:07,500
+interesting thing with that is it's also for historical values 
+
+2448
+01:18:07,500 --> 01:18:14,238
+so if you're just doing bulk collection of all the observables in your network
+
+2451
+01:18:14,238 --> 01:18:26,500
+and then even half a year later if it turns out that a indicator is being shared with you 
+
+2454
+01:18:26,500 --> 01:18:27,0
+that correlates with an observable that SightingDB from half a year ago 
+
+2456
+01:18:27,0 --> 01:18:30,0 
+then you know that you might need to launch an investigation into something
+
+2459
+01:18:30,0 --> 01:18:34,0
+that happened half a year ago in logs and so on based on the historic look up. 
+
+2460
+01:18:38,0 --> 01:18:41,0
+Alex
+
+2462
+01:18:41,0 --> 01:18:44,500
+Just complementary notes regarding sightings and
+
+2464
+01:18:44,500 --> 01:18:49,439
+that's something that is basically maybe the easiest way of sharing additional information
+
+2467
+01:18:49,439 --> 01:18:53,839
+it costs nothing and if you are connected to a MISP instance
+
+2468
+01:18:53,839 --> 01:18:56,319
+and you can tell someone else that you have seen it 
+
+2469
+01:18:56,319 --> 01:18:59,900
+it's really a quick thing that can be useful for many organizations.
+
+2473
+01:18:59,900 --> 01:19:04,500
+So the sighting itself sounds like a very small feature
+
+2474
+01:19:04,500 --> 01:19:10,399
+but at the end, it's a an easy one for contributing and helping the others to know
+
+2478
+01:19:10,399 --> 01:19:15,0
+if an indicator is still valuable and so on, so sighting is really something that 
+
+2481
+01:19:15,0 --> 01:19:22,920
+can basically be a kind of of entry-level things to do when sharing information 
+
+2484
+01:19:22,920 --> 01:19:28,500
+Something else that we have in MISP, this one is I think becoming more and more important
+
+2487
+01:19:28,500 --> 01:19:32,239
+and we will do a quick demo later regarding that.
+
+2489
+01:19:32,238 --> 01:19:37,0
+It's a timeline, i mean when we do analysis and so on,
+ 
+2490
+01:19:37,0 --> 01:19:40,0
+it's really i would say common to have a first seen, last seen 
+
+2492
+01:19:40,0 --> 01:19:42,159
+to see the evolution of things over time.
+
+2494
+01:19:42,159 --> 01:19:45,198
+In the example that you see on the screen there
+
+2496
+01:19:45,198 --> 01:19:47,319
+It's based on specific threat actors
+
+2497
+01:19:47,319 --> 01:19:54,839
+that sends a significant numbers of spear phishing 
+
+2499
+01:19:54,839 --> 01:20:00,0
+and those spear phishing are very well known when we collect those timestamps and so on.
+
+2503
+01:20:00,0 --> 01:20:03,0
+So you can really see and trace the evolution of a specific group and so on.
+
+2506
+01:20:03,0 --> 01:20:07,500
+This can be done automatically, for example passive dns records
+
+2507
+01:20:07,500 --> 01:20:13,0
+I have very often the first seen, last seen and automatically you can really build
+
+2510
+01:20:13,0 --> 01:20:18,0
+and create this kind of timeline because it can be really cumbersome if you have to do it manually
+
+2514
+01:20:18,0 --> 01:20:22,239
+So we have a nice view like that so that means every time you set a first seen, last seen
+
+2516
+01:20:22,239 --> 01:20:26,0
+on any attribute, object, and so on; it automatically populate on the timeline
+
+2518
+01:20:26,0 --> 01:20:31,7
+and it's an easy way to to see evolution, trend and so on for your analysis
+
+2521
+01:20:31,700 --> 01:20:39,280
+and this is a completely interactive so you can navigate over that.
+
+2522
+01:20:39,280 --> 01:20:42,0
+We will show that later.
+
+2524
+01:20:43,0 --> 01:20:47,39
+So for life cycle management, again this is something that we show briefly but 
+
+2527
+01:20:47,39 --> 01:20:49,480
+we're going to way more depth about that tomorrow 
+
+2528
+01:20:49,480 --> 01:20:53,519
+is basically here we see some examples of some attributes 
+
+2531
+01:20:53,519 --> 01:20:58,800
+that have scores applied to them coming from different scoring models.
+
+2532
+01:20:58,800 --> 01:21:03,0
+So we see there an IDS simple decaying model and then a custom model 
+
+2533
+01:21:03,0 --> 01:21:08,800
+titled "Model 5" that are basically running on each of those indicators 
+
+2535
+01:21:08,800 --> 01:21:13,500
+and they generate a score taking into account for things such as labels that are attached to them,
+
+2536
+01:21:13,500 --> 01:21:17,0
+the timestamp on when the attribute was created 
+
+2537
+01:21:17,0 --> 01:21:21,0
+as well as the timestamp of the different sightings that came in so generally
+
+2544
+01:21:21,0 --> 01:21:24,0
+if something is still being actively seen in your network 
+
+2545
+01:21:24,0 --> 01:21:28,0
+that is still relevant despite the indicator itself being perhaps older 
+
+2546
+01:21:28,0 --> 01:21:33,520
+and then using the score that gets generated from these different models that you define
+
+2551
+01:21:33,520 --> 01:21:37,500
+you can basically then make those decisions when you're exporting data to only include
+
+2554
+01:21:37,500 --> 01:21:43,0
+data above a certain threshold when you're feeding your SIEM for example.
+
+2556
+01:21:44,79 --> 01:21:48,500
+Yeah, and this one is quite interesting because you can really define 
+
+2557
+01:21:48,500 --> 01:21:52,159
+so the thing that is really important with the decaying of indicators
+
+2559
+01:21:52,159 --> 01:21:58,920
+you are not modifying that actually you are really just updating and overlapping 
+
+2564
+01:21:58,920 --> 01:22:01,759
+and you can just define those kind of models so that means for example
+
+2566
+01:22:01,759 --> 01:22:05,39
+even within a team where you don't agree on a specific model, you can have both models.
+
+2569
+01:22:05,39 --> 01:22:09,679
+It's very common, for example, to have models for intrusion detection systems
+
+2571
+01:22:09,679 --> 01:22:16,719
+and specific models for i don't know, endpoint, {inaudiable} or endpoint protection device
+
+2574
+01:22:16,719 --> 01:22:20,639
+and in MISP you have even a models or kind of simulator 
+
+2575
+01:22:20,639 --> 01:22:25,500
+where you can simulate the different model that you want to apply
+
+2578
+01:22:25,500 --> 01:22:28,920
+and to see what kind of lifetime you want to apply,
+
+2579
+01:22:28,920 --> 01:22:32,0
+when it decay, when for example you have a specific threshold where 
+
+2582
+01:22:32,0 --> 01:22:39,500
+basically say okay you don't use anymore those kind of data and you can do the mapping with 
+ 
+2583
+01:22:39,500 --> 01:22:45,500
+specific taxonomies you can with the different types, attributes, and so on
+
+2585
+01:22:45,500 --> 01:22:49,0
+directly in MISP and it is really a quick win.
+
+2588
+01:22:49,0 --> 01:22:53,500
+So you are not bound, for example, we know that some TIPs for example 
+
+2591
+01:22:53,500 --> 01:22:58,479
+have a kind of system-wide decaying models in MISP it is not like that,
+
+2593
+01:22:56,880 --> 01:23:02,679
+everyone has their models, we are sharing some models 
+
+2594
+01:23:02,679 --> 01:23:06,0
+and you can define what you want to use without really altering the data.
+
+2598
+01:23:06,0 --> 01:23:10,238
+So that means this kind of of information there is just an overlay 
+
+2599
+01:23:10,238 --> 01:23:15,0
+and you actually keep your own data in the systems without having any modification.
+
+2601
+01:23:17,0 --> 01:23:24,0
+And you can simulate that one.
+
+2605
+01:23:27,0 --> 01:23:31,0
+So when it comes to starting out, one of the trickiest things obviously is 
+
+2606
+01:23:31,0 --> 01:23:34,0
+when you're starting out with MISP is if you're staring as an empty instance 
+
+2607
+01:23:34,0 --> 01:23:37,198
+then getting started and encoding information is really tough 
+
+2610
+01:23:37,198 --> 01:23:40,0
+because you don't know what is really expected from the communities out there, you don't know how.
+
+2612
+01:23:40,0 --> 01:23:44,0
+It's a new tool, you don't really know how to get started. 
+
+2616
+01:23:44,0 --> 01:23:50,239
+So in order to ease this a little bit there are a bunch of different feeds some of those that we also provide ourselves
+
+2619
+01:23:50,239 --> 01:23:54,500
+which is obviously operational information something that you can use directly
+
+2622
+01:23:54,500 --> 01:24:00,799
+so these are OSINT feeds that we produce as well from our TLP white data set 
+
+2623
+01:24:00,799 --> 01:24:04,0
+and the idea is that this will really help with bootstrapping your processes.
+
+2625
+01:24:04,0 --> 01:24:08,0
+Look at the data we consider that generally well-formed
+
+2629
+01:24:08,0 --> 01:24:12,500
+and well contextualized. It should give you an idea of what data generally looks like in MISP.
+
+2631
+01:24:12,500 --> 01:24:15,500
+So don't start out with a fresh instance, 
+
+2632
+01:24:15,500 --> 01:24:18,0
+just go to your feed menu in your MISP when you're installing it
+
+2633
+01:24:18,0 --> 01:24:22,500
+and pull in some of these OSINT feeds so that you see the information already.
+
+2636
+01:24:23,500 --> 01:24:27,359
+Also it's a great way to test your internal tooling 
+
+2637
+01:24:27,359 --> 01:24:31,119
+so if you want to test the APIs, if you want to test internal synchronization,
+
+2640
+01:24:31,119 --> 01:24:33,500
+it's good to have larger data set already from the get go 
+
+2641
+01:24:33,500 --> 01:24:38,679
+so that you already see that the movement of the data is working as expected.
+
+2645
+01:24:38,679 --> 01:24:44,500
+Yeah, the other thing that you can do and where we're going to talk about that quite a bit tomorrow
+
+2648
+01:24:44,500 --> 01:24:50,500
+is basically figuring out which feeds are worth ingesting,
+
+2650
+01:24:50,500 --> 01:24:55,719
+how the feeds compare to each other, running overlap analysis between them and so on
+
+2653
+01:24:55,719 --> 01:25:00,0
+So this is something that this is quite a heavy topic for tomorrow.
+
+2656
+01:25:05,0 --> 01:25:08,0
+You're muted alex. 
+
+2657
+01:25:08,0 --> 01:25:09,500
+Yeah just discover {inaudiable this/MISP}.
+
+2658
+01:25:09,500 --> 01:25:12,0
+So as you can see for MISP,
+
+2659
+01:25:12,0 --> 01:25:15,300
+it's the development of MISP already done over the years, 
+
+2661
+01:25:15,300 --> 01:25:19,760
+based on the feedback of users and that's really one of the key elements for us.
+
+2663
+01:25:19,760 --> 01:25:22,0
+We wanted a tool for us that works 
+
+2665
+01:25:22,0 --> 01:25:28,879
+and it's key and based on that we wanted something that works for others too
+
+2667
+01:25:28,880 --> 01:25:33,679
+and i mean the tool is evolving over time so you see that we have plenty of functionalities
+
+2670
+01:25:33,679 --> 01:25:37,79
+On those two days of workshop we'll try to cover a part of it,
+
+2672
+01:25:37,79 --> 01:25:41,679
+we had already some good questions regarding how to customize this and so on.
+
+2675
+01:25:41,679 --> 01:25:45,119
+We might give you some hints how to do it and and so on,
+
+2677
+01:25:45,119 --> 01:25:47,0
+so we won't be able to cover everything in those two days 
+
+2678
+01:25:47,0 --> 01:25:54,0
+but you'll see that you can really update MISP based on your specific use cases and so on. 
+
+2679
+01:25:54,0 --> 01:26:00,500
+So MISP is there as a tool, what really usually matters and are the successful,
+
+2680
+01:26:00,500--> 01:26:07,0
+I would say, sharing communities depends on the practices or you do that and so on
+
+2687
+01:26:07,0 --> 01:26:11,0
+and we really want at least at the end, even if it's a complex tool and so on 
+
+2690
+01:26:11,0 --> 01:26:15,520
+to be as easy as possible for covering different use case 
+
+2691
+01:26:15,520 --> 01:26:17,500
+and that's really the thing that we want to do, 
+
+2693
+01:26:17,500 --> 01:26:19,520
+is for example for a lot of things that we have in MISP 
+
+2694
+01:26:19,520 --> 01:26:23,700
+and someone just asked the questions about how can you customize MISP
+
+2697
+01:26:23,700 --> 01:26:27,119
+a lot of things in MISP can be customized by just modifying some JSON files.
+
+2700
+01:26:27,119 --> 01:26:32,519
+It's the case for MISP objects so if you want to create a new object you just update the json files,
+
+2701 
+01:26:32,519 --> 01:26:39,500
+if you want to, for example, create a new taxonomies or create a new galaxy 
+
+2706
+01:26:39,50 --> 01:26:41,839
+you just create those kind of json files.
+
+2708
+01:26:41,839 --> 01:26:45,500
+You have other ways to update and change the behavior of MISP.
+
+2709
+01:26:45,500 --> 01:26:48,158
+it's based for example on MISP modules
+
+2710
+01:26:48,158 --> 01:26:51,439
+so if you want to change the behavior of the expansion and so on
+
+2712
+01:26:51,439 --> 01:26:58,800
+you can just play with MISP modules and we will quickly show you some examples on these modules
+
+2716
+01:26:58,800 --> 01:27:02,80
+but that's really simple i mean there's no {inaudiable}
+
+2719
+01:27:02,80 --> 01:27:10,239
+and that's the thing that you have to understand with MISP project is not just a small open source software somewhere
+
+2720
+01:27:10,239 --> 01:27:16,800
+it's really a set of combination of tool, software, packages, open standards,
+
+2721
+01:27:16,800 --> 01:27:23,799
+various best practices, shared knowledge base and obviously the community is using it.
+
+2728
+01:27:23,799 --> 01:27:26,500
+So that's really the thing that we will have we love with FIRST for example. 
+
+2731
+01:27:26,500 --> 01:27:31,0
+it is to have this kind of community, learning together, sharing information,
+
+2732
+01:27:31,0 --> 01:27:33,119
+and so that's that's really a key for us.
+
+2735
+01:27:33,119 --> 01:27:41,500
+We have, I think more than 500 contributors on the MISP project with even more nowadays.
+
+2738
+01:27:41,500 --> 01:27:45,500
+So if you want to become one of the contributors it's really straightforward i mean
+
+2739
+01:27:45,500 --> 01:27:48,800
+if you have something, a problem that you want to solve,
+
+2742
+01:27:48,800 --> 01:27:51,400
+for example on an object, you just do a pull request and
+
+2743
+01:27:51,400 --> 01:27:55,840
+it will be in MISP immediately and you become a contributor in the project 
+
+2747
+01:27:57,679 --> 01:27:58,0
+so really for us, it's really key in MISP 
+
+2748
+01:27:58,0 --> 01:28:02,0
+is to have a kind of tool that is supporting the different use cases
+
+2749
+01:28:02,0 --> 01:28:06,238
+Okay so before that, we do a break i will share you with you 
+
+2750
+01:28:06,238 --> 01:28:12,759
+some practical details on accessing the MISP training instance because there were some questions regarding that
+
+2755
+01:28:12,759 --> 01:28:20,0
+and after the break, we will do the hands-on practical session 
+
+2756
+01:28:20,0 --> 01:28:25,359
+with an example, so we will with a real example, so you will create the full event 
+
+2757
+01:28:25,359 --> 01:28:27,359
+based on some information that you receive.
+
+2759
+01:28:27,359 --> 01:28:36,500
+So first of all, I will give you some details about how to access the MISP instance.
+
+
+2763
+01:28:36,500 --> 01:28:42,500
+S0, first of all we have a {inaudiable acting/active} page 
+
+2764
+01:28:42,500 --> 01:28:48,500
+which I obviously share at some point in time and i will share it again.
+
+2766
+01:28:48,500 --> 01:28:54,799
+Yes. So there's a page with some pages that you can even edit.
+
+2769
+01:28:54,799 --> 01:29:00,0
+I will paste the link again in the chat for everyone.
+
+2772
+01:29:05,639 --> 01:29:11,319
+That's the link, so we have a 50 account on the training instance. 
+
+2773
+01:29:11,319 --> 01:29:14,159
+Pick randomly one
+
+2775
+01:29:14,158 --> 01:29:18,0
+it doesn't matter if you are multiple one using the same account but be careful
+
+2777
+01:29:18,0 --> 01:29:22,119
+don't change the password because maybe some people will complain,
+
+2780
+01:29:22,119 --> 01:29:30,800
+and then we have a "TrainingFIRST2021" password so super simple
+
+2782
+01:29:30,800 --> 01:29:33,600
+not so secure but that's fine it's a training instance.
+
+2785
+01:29:33,600 --> 01:29:41,0
+Just for the reference, for the one that doesn't want to use the training instance
+
+2786
+01:29:41,0 --> 01:29:44,0
+sometimes for whatever reason you want to use your own instance.
+
+2788
+01:29:44,0 --> 01:29:50,238
+We have different images, virtual box and VMware images for MISP.
+
+2791
+01:29:50,238 --> 01:29:54,158
+So if you want to play with MISP locally and so on.
+
+2793
+01:29:54,158 --> 01:29:57,279
+If you want to play with synchronization too, you can even connect those two 
+
+2794
+01:29:59,500 --> 01:30:05,280
+So and during the sessions we will connect to that instance so the instant is "iglocska.eu"
+
+2796
+01:30:05,280 --> 01:30:14,0
+and when you connect, you will get access to the instance.
+
+2799
+01:30:14,0 --> 01:30:18,158
+So you enter your training password so I will enter with my specific account
+
+2802
+01:30:18,158 --> 01:30:23,500
+and we will use that instance for the hands-on that we will do just after the break.
+
+2804
+01:30:23,500 --> 01:30:31,0
+So what i propose now is to do a 15 minute break and we start at 45, if it's fine for everyone
+
+2808
+01:30:31,0 --> 01:30:39,600
+and we will start by with the practical sessions with a specific email
+
+2811
+01:30:39,600 --> 01:30:43,600
+that we will share in the {inaudiable} as a practical example
+
+ 2813
+01:30:43,600 --> 01:30:51,300 
+so thank you for the one that join us now and we will start again at 45 
+
+2814
+01:30:51,300 --> 01:30:54,500
+to do the hands-on session. Thank you very much.
+
+2817
+01:30:55,500 --> 01:30:57,500
+Thank you.
+
+TODO
+2819
+01:44:10,399 --> 01:44:15,118
+okay and shall we get started
+
+2820
+01:44:16,238 --> 01:44:22,559
+sure welcome back everyone
+
+2821
+01:44:20,79 --> 01:44:24,399
+okay so now what we're going to be doing
+
+2822
+01:44:22,560 --> 01:44:26,80
+is we're going to look a little bit
+
+2823
+01:44:24,399 --> 01:44:27,679
+at miss pizza so we've talked plenty
+
+2824
+01:44:26,79 --> 01:44:28,960
+about it but we haven't actually done
+
+2825
+01:44:27,679 --> 01:44:30,560
+anything with it yet
+
+2826
+01:44:28,960 --> 01:44:32,560
+so i really encourage everyone that has
+
+2827
+01:44:30,560 --> 01:44:35,199
+a misfits to also play along
+
+2828
+01:44:32,560 --> 01:44:36,800
+and to create your own events what we're
+
+2829
+01:44:35,198 --> 01:44:37,439
+going to be doing is we're going to go
+
+2830
+01:44:36,800 --> 01:44:40,639
+through as
+
+2831
+01:44:37,439 --> 01:44:41,359
+any fictional little exercise assume
+
+2832
+01:44:40,639 --> 01:44:44,0
+6280.639 --> 6284
+that you
+
+2833
+01:44:41,359 --> 01:44:44,799
+that you receive an email from uh in
+
+2834
+01:44:44,0 --> 01:44:46,560
+6284 --> 6286.56
+this case
+
+2835
+01:44:44,800 --> 01:44:49,840
+luxembourg english telco this is certain
+
+2836
+01:44:46,560 --> 01:44:52,80
+of them describing an incident of a very
+
+2837
+01:44:49,840 --> 01:44:53,520
+simplistic incident
+
+2838
+01:44:52,79 --> 01:44:56,479
+of what happened what we're going to be
+
+2839
+01:44:53,520 --> 01:44:59,280
+trying to do now is to model this a miss
+
+2840
+01:44:56,479 --> 01:45:00,839
+and to explain how you can further
+
+2841
+01:44:59,279 --> 01:45:02,800
+improve it and contextualize this
+
+2842
+01:45:00,840 --> 01:45:05,39
+information
+
+2843
+01:45:02,800 --> 01:45:06,239
+so before we start uh once you're logged
+
+2844
+01:45:05,39 --> 01:45:08,639
+into the
+
+2845
+01:45:06,238 --> 01:45:09,678
+into miss pinsons such as the hosted
+
+2846
+01:45:08,639 --> 01:45:11,359
+training instance
+
+2847
+01:45:09,679 --> 01:45:13,840
+this is what you're going to be seeing
+
+2848
+01:45:11,359 --> 01:45:15,198
+so it's a it's a little bit squeezed on
+
+2849
+01:45:13,840 --> 01:45:18,639
+alex's screen
+
+2850
+01:45:15,198 --> 01:45:21,599
+but the idea is that you have a list of
+
+2851
+01:45:18,639 --> 01:45:23,279
+events that are listed on the main page
+
+2852
+01:45:21,600 --> 01:45:25,280
+so we're in the event index this is our
+
+2853
+01:45:23,279 --> 01:45:26,719
+landing page when we load up misp
+
+2854
+01:45:25,279 --> 01:45:28,79
+and each of these individual lines
+
+2855
+01:45:26,719 --> 01:45:30,158
+represents an event so they're
+
+2856
+01:45:28,79 --> 01:45:33,519
+describing either an attack
+
+2857
+01:45:30,158 --> 01:45:34,960
+or perhaps a report recurring
+
+2858
+01:45:33,520 --> 01:45:38,800
+distribution
+
+2859
+01:45:34,960 --> 01:45:40,0
+6334.96 --> 6340
+or a certain type of of indicator lists
+
+2860
+01:45:38,800 --> 01:45:41,600
+and so on
+
+2861
+01:45:40,0 --> 01:45:43,439
+6340 --> 6343.44
+so what you're seeing here is you have
+
+2862
+01:45:41,600 --> 01:45:45,679
+each of these events having an id
+
+2863
+01:45:43,439 --> 01:45:47,359
+and some metadata around it so these are
+
+2864
+01:45:45,679 --> 01:45:48,960
+this metadata can be either coming from
+
+2865
+01:45:47,359 --> 01:45:50,719
+this galaxy cluster
+
+2866
+01:45:48,960 --> 01:45:52,639
+system that we mentioned for example
+
+2867
+01:45:50,719 --> 01:45:55,679
+describing different
+
+2868
+01:45:52,639 --> 01:45:56,880
+attacker techniques the different types
+
+2869
+01:45:55,679 --> 01:45:58,560
+of
+
+2870
+01:45:56,880 --> 01:46:00,560
+ransomwares in this case or attack
+
+2871
+01:45:58,560 --> 01:46:02,0
+6358.56 --> 6362
+patterns that are leveraged
+
+2872
+01:46:00,560 --> 01:46:03,520
+and then if we scroll a bit further
+
+2873
+01:46:02,0 --> 01:46:04,319
+6362 --> 6364.32
+right so this is a bit lower resolution
+
+2874
+01:46:03,520 --> 01:46:06,800
+there that we see
+
+2875
+01:46:04,319 --> 01:46:07,920
+but uh you should have it visible on the
+
+2876
+01:46:06,800 --> 01:46:12,159
+same page
+
+2877
+01:46:07,920 --> 01:46:14,239
+um you see the information about uh
+
+2878
+01:46:12,158 --> 01:46:15,439
+what this event is trying to describe to
+
+2879
+01:46:14,238 --> 01:46:17,198
+us
+
+2880
+01:46:15,439 --> 01:46:19,599
+it's simple to understand text-based
+
+2881
+01:46:17,198 --> 01:46:21,198
+representation now this instance is used
+
+2882
+01:46:19,600 --> 01:46:22,719
+for trainings in general so it's going
+
+2883
+01:46:21,198 --> 01:46:24,559
+to be filled with a lot of junk
+
+2884
+01:46:22,719 --> 01:46:27,39
+interspersed with real data that is
+
+2885
+01:46:24,560 --> 01:46:28,800
+coming from our tlp wide feed
+
+2886
+01:46:27,39 --> 01:46:31,679
+so you're going to see some obviously
+
+2887
+01:46:28,800 --> 01:46:33,840
+weird events in there
+
+2888
+01:46:31,679 --> 01:46:35,840
+these are just there for testing just
+
+2889
+01:46:33,840 --> 01:46:37,199
+players playing during an exercise and
+
+2890
+01:46:35,840 --> 01:46:40,159
+so on
+
+2891
+01:46:37,198 --> 01:46:41,439
+but also some real events there so what
+
+2892
+01:46:40,158 --> 01:46:43,118
+we're going to be doing now is we're
+
+2893
+01:46:41,439 --> 01:46:44,879
+going to create our own event based on
+
+2894
+01:46:43,118 --> 01:46:45,759
+that email that we received it's also on
+
+2895
+01:46:44,880 --> 01:46:47,600
+the hackamd
+
+2896
+01:46:45,760 --> 01:46:48,880
+page so just have a look at email
+
+2897
+01:46:47,600 --> 01:46:51,119
+exactly
+
+2898
+01:46:48,880 --> 01:46:52,239
+and we need to start encoding with that
+
+2899
+01:46:51,118 --> 01:46:54,319
+event
+
+2900
+01:46:52,238 --> 01:46:55,839
+so before we include anything in misp
+
+2901
+01:46:54,319 --> 01:46:57,920
+the first thing that we need to do
+
+2902
+01:46:55,840 --> 01:47:00,239
+is we need to create a new event so this
+
+2903
+01:46:57,920 --> 01:47:02,399
+is where everything starts
+
+2904
+01:47:00,238 --> 01:47:04,238
+way to do it is to just click on add
+
+2905
+01:47:02,399 --> 01:47:05,359
+event on the left side of the menu
+
+2906
+01:47:04,238 --> 01:47:07,359
+and then you start with a very
+
+2907
+01:47:05,359 --> 01:47:11,198
+simplistic form that where we can
+
+2908
+01:47:07,359 --> 01:47:13,679
+describe the event in a very high level
+
+2909
+01:47:11,198 --> 01:47:15,118
+so here you see it's it's the first step
+
+2910
+01:47:13,679 --> 01:47:16,399
+is very straightforward
+
+2911
+01:47:15,118 --> 01:47:17,920
+the import the things that we have to
+
+2912
+01:47:16,399 --> 01:47:18,479
+watch out for or here is we already
+
+2913
+01:47:17,920 --> 01:47:20,239
+decide
+
+2914
+01:47:18,479 --> 01:47:22,638
+who gets to see the event so this is the
+
+2915
+01:47:20,238 --> 01:47:23,279
+distribution level and that we need to
+
+2916
+01:47:22,639 --> 01:47:25,520
+set and
+
+2917
+01:47:23,279 --> 01:47:27,599
+basically a basic description of it as
+
+2918
+01:47:25,520 --> 01:47:30,159
+for the distribution itself
+
+2919
+01:47:27,600 --> 01:47:32,159
+you have different uh ways of
+
+2920
+01:47:30,158 --> 01:47:33,679
+interacting with the data here already
+
+2921
+01:47:32,158 --> 01:47:35,359
+so one of the decisions that you have to
+
+2922
+01:47:33,679 --> 01:47:35,760
+make even if you're going to share to
+
+2923
+01:47:35,359 --> 01:47:37,759
+the
+
+2924
+01:47:35,760 --> 01:47:40,0
+6455.76 --> 6460
+wider community out there is do i keep
+
+2925
+01:47:37,760 --> 01:47:41,119
+this internal until i'm ready to share
+
+2926
+01:47:40,0 --> 01:47:43,118
+6460 --> 6463.119
+it with the community
+
+2927
+01:47:41,118 --> 01:47:44,719
+or do i already make it visible to
+
+2928
+01:47:43,118 --> 01:47:46,559
+anyone that has access to the data in
+
+2929
+01:47:44,719 --> 01:47:48,960
+the community
+
+2930
+01:47:46,560 --> 01:47:50,800
+now keep in mind that we have a
+
+2931
+01:47:48,960 --> 01:47:52,79
+publishing process in misp so until an
+
+2932
+01:47:50,800 --> 01:47:54,320
+event is published
+
+2933
+01:47:52,79 --> 01:47:55,118
+it is not propagated out to other missed
+
+2934
+01:47:54,319 --> 01:47:56,639
+instances
+
+2935
+01:47:55,118 --> 01:47:58,158
+that means anyone on the current miss
+
+2936
+01:47:56,639 --> 01:47:59,679
+pencils can see the data
+
+2937
+01:47:58,158 --> 01:48:02,0
+6478.159 --> 6482
+but it will not jump to a different
+
+2938
+01:47:59,679 --> 01:48:04,319
+misspen since at this point in any way
+
+2939
+01:48:02,0 --> 01:48:05,439
+6482 --> 6485.44
+but if you if you're creating it on a
+
+2940
+01:48:04,319 --> 01:48:07,679
+hosted instance
+
+2941
+01:48:05,439 --> 01:48:08,799
+for example if you if your isak is
+
+2942
+01:48:07,679 --> 01:48:10,319
+running a miss pinstance and you're
+
+2943
+01:48:08,800 --> 01:48:11,840
+creating it on that one directly
+
+2944
+01:48:10,319 --> 01:48:14,0
+6490.32 --> 6494
+then this already has an impact on who
+
+2945
+01:48:11,840 --> 01:48:16,400
+can see the data
+
+2946
+01:48:14,0 --> 01:48:18,0
+6494 --> 6498
+so the option here either go with your
+
+2947
+01:48:16,399 --> 01:48:19,519
+organization only and then
+
+2948
+01:48:18,0 --> 01:48:21,679
+6498 --> 6501.679
+raise the distribution level once it's
+
+2949
+01:48:19,520 --> 01:48:23,840
+ready to be released or you already
+
+2950
+01:48:21,679 --> 01:48:25,440
+involve addressing the process and you
+
+2951
+01:48:23,840 --> 01:48:27,279
+pick something like community only where
+
+2952
+01:48:25,439 --> 01:48:28,319
+others can chip in with their ideas from
+
+2953
+01:48:27,279 --> 01:48:30,960
+the get-go
+
+2954
+01:48:28,319 --> 01:48:32,559
+so this is up to you it's a risk versus
+
+2955
+01:48:30,960 --> 01:48:34,719
+efficiency question
+
+2956
+01:48:32,560 --> 01:48:35,600
+do i want to share the information and
+
+2957
+01:48:34,719 --> 01:48:37,760
+potentially
+
+2958
+01:48:35,600 --> 01:48:39,199
+overshare a bit by including by
+
+2959
+01:48:37,760 --> 01:48:40,960
+accidentally uploading information that
+
+2960
+01:48:39,198 --> 01:48:43,198
+is not yet
+
+2961
+01:48:40,960 --> 01:48:45,679
+confirmed that it can be shared out
+
+2962
+01:48:43,198 --> 01:48:47,439
+versus losing out on perhaps others
+
+2963
+01:48:45,679 --> 01:48:49,118
+immediately jumping on board and saying
+
+2964
+01:48:47,439 --> 01:48:50,399
+okay this is also something we've seen
+
+2965
+01:48:49,118 --> 01:48:51,599
+we've already done the analysis of it
+
+2966
+01:48:50,399 --> 01:48:53,599
+here you go
+
+2967
+01:48:51,600 --> 01:48:54,960
+so you have to balance those two things
+
+2968
+01:48:53,600 --> 01:48:59,39
+out so let's start
+
+2969
+01:48:54,960 --> 01:49:01,920
+no for example for example what
+
+2970
+01:48:59,39 --> 01:49:03,359
+you have is when people are working on a
+
+2971
+01:49:01,920 --> 01:49:06,960
+case by default they say
+
+2972
+01:49:03,359 --> 01:49:08,79
+it's organization and at one point in
+
+2973
+01:49:06,960 --> 01:49:10,79
+time
+
+2974
+01:49:08,79 --> 01:49:11,840
+the team lead for example decide at some
+
+2975
+01:49:10,79 --> 01:49:13,359
+point it's okay no you can share it
+
+2976
+01:49:11,840 --> 01:49:16,239
+to a wider community and then you change
+
+2977
+01:49:13,359 --> 01:49:17,839
+the distribution level
+
+2978
+01:49:16,238 --> 01:49:19,519
+yeah indeed so let's start with the
+
+2979
+01:49:17,840 --> 01:49:20,800
+organization only for now uh
+
+2980
+01:49:19,520 --> 01:49:22,560
+for different reasons that we'll get
+
+2981
+01:49:20,800 --> 01:49:24,0
+6560.8 --> 6564
+back to later on it allows us to show
+
+2982
+01:49:22,560 --> 01:49:25,119
+off another feature afterwards that is
+
+2983
+01:49:24,0 --> 01:49:26,800
+6564 --> 6566.8
+handy
+
+2984
+01:49:25,118 --> 01:49:28,639
+so we start with that then we have to
+
+2985
+01:49:26,800 --> 01:49:29,199
+describe this the threat level so this
+
+2986
+01:49:28,639 --> 01:49:31,840
+is
+
+2987
+01:49:29,198 --> 01:49:33,598
+a very subjective question uh threat
+
+2988
+01:49:31,840 --> 01:49:34,800
+level will depend a lot on what sort of
+
+2989
+01:49:33,599 --> 01:49:36,560
+an organization you are
+
+2990
+01:49:34,800 --> 01:49:38,0
+6574.8 --> 6578
+versus who you're sharing it with so we
+
+2991
+01:49:36,560 --> 01:49:40,400
+all have different interpretations of
+
+2992
+01:49:38,0 --> 01:49:41,760
+6578 --> 6581.76
+what we consider a high threat level
+
+2993
+01:49:40,399 --> 01:49:43,679
+we have some descriptions for each of
+
+2994
+01:49:41,760 --> 01:49:45,520
+these fields uh
+
+2995
+01:49:43,679 --> 01:49:46,800
+predefined if you click on the little
+
+2996
+01:49:45,520 --> 01:49:49,199
+information box
+
+2997
+01:49:46,800 --> 01:49:51,520
+it will tell you that hi is uh
+
+2998
+01:49:49,198 --> 01:49:53,519
+sophisticated apt malware or zero day
+
+2999
+01:49:51,520 --> 01:49:55,40
+attack
+
+3000
+01:49:53,520 --> 01:49:57,599
+please just freely disregard this
+
+3001
+01:49:55,39 --> 01:49:58,479
+because nowadays a lot of information
+
+3002
+01:49:57,599 --> 01:50:00,159
+sharing
+
+3003
+01:49:58,479 --> 01:50:02,79
+happens in completely different domains
+
+3004
+01:50:00,158 --> 01:50:03,598
+so if a fraud team is sharing
+
+3005
+01:50:02,79 --> 01:50:06,880
+information about
+
+3006
+01:50:03,599 --> 01:50:08,400
+fraudster their definition of high
+
+3007
+01:50:06,880 --> 01:50:08,719
+threat level would be very different
+
+3008
+01:50:08,399 --> 01:50:11,439
+from
+
+3009
+01:50:08,719 --> 01:50:13,198
+those in cyber security for example so
+
+3010
+01:50:11,439 --> 01:50:15,519
+generally it's just a subjective
+
+3011
+01:50:13,198 --> 01:50:17,198
+first measure but a lot of organizations
+
+3012
+01:50:15,520 --> 01:50:19,40
+users use this to briefly filter out
+
+3013
+01:50:17,198 --> 01:50:21,439
+what they should tackle first
+
+3014
+01:50:19,39 --> 01:50:22,960
+so still use it with care if you don't
+
+3015
+01:50:21,439 --> 01:50:25,759
+want to use this field
+
+3016
+01:50:22,960 --> 01:50:27,679
+picking undefined is fine too analysis
+
+3017
+01:50:25,760 --> 01:50:30,560
+the next field describes how far along
+
+3018
+01:50:27,679 --> 01:50:33,39
+you've come with the analysis process
+
+3019
+01:50:30,560 --> 01:50:34,480
+so basically uh with this what you're
+
+3020
+01:50:33,39 --> 01:50:36,158
+telling the communities i'm just
+
+3021
+01:50:34,479 --> 01:50:39,118
+starting out with the analysis
+
+3022
+01:50:36,158 --> 01:50:40,719
+these are my initial findings versus for
+
+3023
+01:50:39,118 --> 01:50:41,839
+example saying that my analysis process
+
+3024
+01:50:40,719 --> 01:50:44,960
+is already complete
+
+3025
+01:50:41,840 --> 01:50:48,0
+6641.84 --> 6648
+i'm not going to be digging more for now
+
+3026
+01:50:44,960 --> 01:50:50,840
+i consider this complete if you have
+
+3027
+01:50:48,0 --> 01:50:54,960
+6648 --> 6654.96
+additional information then obviously
+
+3028
+01:50:50,840 --> 01:50:56,880
+uh already start collaborating with us
+
+3029
+01:50:54,960 --> 01:50:58,399
+so just pick whichever is most
+
+3030
+01:50:56,880 --> 01:50:59,840
+appropriate for you let's just go with
+
+3031
+01:50:58,399 --> 01:51:01,679
+initial for now
+
+3032
+01:50:59,840 --> 01:51:04,159
+and then comes the most important part
+
+3033
+01:51:01,679 --> 01:51:06,319
+of this form which is
+
+3034
+01:51:04,158 --> 01:51:08,319
+describing the event info so this is a
+
+3035
+01:51:06,319 --> 01:51:10,158
+brief description for analysts that are
+
+3036
+01:51:08,319 --> 01:51:12,79
+looking at the data that describe
+
+3037
+01:51:10,158 --> 01:51:13,198
+the best described the event that you're
+
+3038
+01:51:12,79 --> 01:51:16,719
+basically uh
+
+3039
+01:51:13,198 --> 01:51:17,678
+sharing now be brief here and be careful
+
+3040
+01:51:16,719 --> 01:51:20,480
+about
+
+3041
+01:51:17,679 --> 01:51:22,639
+including very domain or organization
+
+3042
+01:51:20,479 --> 01:51:23,279
+specific information one of the mistakes
+
+3043
+01:51:22,639 --> 01:51:25,279
+that
+
+3044
+01:51:23,279 --> 01:51:26,319
+that people often make here is for
+
+3045
+01:51:25,279 --> 01:51:29,359
+example uh
+
+3046
+01:51:26,319 --> 01:51:30,479
+typing a ticket number or ticket id in
+
+3047
+01:51:29,359 --> 01:51:32,158
+there
+
+3048
+01:51:30,479 --> 01:51:33,759
+so if you have a ticketing system and
+
+3049
+01:51:32,158 --> 01:51:35,198
+you basically start your investigation
+
+3050
+01:51:33,760 --> 01:51:36,800
+from your ticketing system
+
+3051
+01:51:35,198 --> 01:51:38,719
+sharing out something like what alex has
+
+3052
+01:51:36,800 --> 01:51:40,239
+typed there is not very handy for anyone
+
+3053
+01:51:38,719 --> 01:51:41,679
+else nobody will have a clue what you
+
+3054
+01:51:40,238 --> 01:51:43,198
+mean with that
+
+3055
+01:51:41,679 --> 01:51:44,639
+another mistake that can happen here
+
+3056
+01:51:43,198 --> 01:51:46,0
+6703.199 --> 6706
+very often is especially if you're
+
+3057
+01:51:44,639 --> 01:51:47,840
+starting out small and
+
+3058
+01:51:46,0 --> 01:51:49,760
+6706 --> 6709.76
+in turn initially you're only keeping
+
+3059
+01:51:47,840 --> 01:51:51,520
+the events for yourself
+
+3060
+01:51:49,760 --> 01:51:53,760
+and then perhaps later on you decide
+
+3061
+01:51:51,520 --> 01:51:56,159
+that you want to maybe perhaps
+
+3062
+01:51:53,760 --> 01:51:57,520
+after all share it out to a community
+
+3063
+01:51:56,158 --> 01:51:58,960
+then one of the things that can really
+
+3064
+01:51:57,520 --> 01:52:00,719
+hurt you at that point is if you've
+
+3065
+01:51:58,960 --> 01:52:02,319
+used different language for example to
+
+3066
+01:52:00,719 --> 01:52:03,520
+describe the event info so we've seen
+
+3067
+01:52:02,319 --> 01:52:06,639
+this very often
+
+3068
+01:52:03,520 --> 01:52:07,360
+we instead of describing the things in
+
+3069
+01:52:06,639 --> 01:52:10,480
+english we
+
+3070
+01:52:07,359 --> 01:52:10,479
+choose our own languages
+
+3071
+01:52:14,479 --> 01:52:18,79
+and myself is hungarian we are we're
+
+3072
+01:52:16,719 --> 01:52:21,599
+pretty prone to doing this
+
+3073
+01:52:18,79 --> 01:52:22,639
+in general uh and this is generally
+
+3074
+01:52:21,599 --> 01:52:24,400
+something that will hurt us
+
+3075
+01:52:22,639 --> 01:52:25,920
+in the long term because uh once you
+
+3076
+01:52:24,399 --> 01:52:28,399
+share it out with a more
+
+3077
+01:52:25,920 --> 01:52:30,79
+international community you either have
+
+3078
+01:52:28,399 --> 01:52:32,799
+to go through the effort of translating
+
+3079
+01:52:30,79 --> 01:52:34,399
+it or basically make it illegible for
+
+3080
+01:52:32,800 --> 01:52:36,800
+the recipient
+
+3081
+01:52:34,399 --> 01:52:37,839
+so stick to something simple simple
+
+3082
+01:52:36,800 --> 01:52:41,199
+phrasing
+
+3083
+01:52:37,840 --> 01:52:45,840
+be as concise as possible
+
+3084
+01:52:41,198 --> 01:52:45,839
+but make sure that it's still understood
+
+3085
+01:52:51,920 --> 01:52:55,440
+we know that it's targeting the telco
+
+3086
+01:52:53,359 --> 01:52:57,198
+sector in luxembourg and we know that we
+
+3087
+01:52:55,439 --> 01:52:57,598
+have a malware sample so that's a pretty
+
+3088
+01:52:57,198 --> 01:52:59,598
+nice
+
+3089
+01:52:57,599 --> 01:53:01,39
+short explanation of what the event is
+
+3090
+01:52:59,599 --> 01:53:02,560
+about
+
+3091
+01:53:01,39 --> 01:53:04,800
+so once we click submit we have our
+
+3092
+01:53:02,560 --> 01:53:06,480
+event created and we already see that
+
+3093
+01:53:04,800 --> 01:53:08,400
+that our event suddenly has a lot of
+
+3094
+01:53:06,479 --> 01:53:09,39
+data that we didn't intentionally put in
+
+3095
+01:53:08,399 --> 01:53:11,39
+there yet
+
+3096
+01:53:09,39 --> 01:53:13,359
+so we see a bunch of tags that are
+
+3097
+01:53:11,39 --> 01:53:15,840
+applied to the event we see that
+
+3098
+01:53:13,359 --> 01:53:16,799
+the event already has information about
+
+3099
+01:53:15,840 --> 01:53:18,639
+uh
+
+3100
+01:53:16,800 --> 01:53:20,0
+6796.8 --> 6800
+who created the information who the
+
+3101
+01:53:18,639 --> 01:53:22,0
+6798.639 --> 6802
+local owners and
+
+3102
+01:53:20,0 --> 01:53:24,238
+6800 --> 6804.239
+information and so on so this basically
+
+3103
+01:53:22,0 --> 01:53:25,439
+6802 --> 6805.44
+takes a lot of local settings from uh
+
+3104
+01:53:24,238 --> 01:53:27,519
+from the instance
+
+3105
+01:53:25,439 --> 01:53:28,960
+and it uses the event when it is created
+
+3106
+01:53:27,520 --> 01:53:31,199
+with these basic datasets
+
+3107
+01:53:28,960 --> 01:53:33,439
+a lot of these also involve the
+
+3108
+01:53:31,198 --> 01:53:35,118
+contextualization that we start out with
+
+3109
+01:53:33,439 --> 01:53:36,559
+so it might seem a little bit pointless
+
+3110
+01:53:35,118 --> 01:53:38,479
+to immediately
+
+3111
+01:53:36,560 --> 01:53:40,0
+6816.56 --> 6820
+label something that we have not even
+
+3112
+01:53:38,479 --> 01:53:42,79
+started working on yet
+
+3113
+01:53:40,0 --> 01:53:43,359
+6820 --> 6823.36
+but also keep in mind that very often
+
+3114
+01:53:42,79 --> 01:53:45,118
+what we do internally in our
+
+3115
+01:53:43,359 --> 01:53:46,79
+organizations is we have several missed
+
+3116
+01:53:45,118 --> 01:53:49,359
+instances
+
+3117
+01:53:46,79 --> 01:53:51,198
+that are uh that already are domain
+
+3118
+01:53:49,359 --> 01:53:52,799
+specific so for example we have our spam
+
+3119
+01:53:51,198 --> 01:53:56,0
+6831.199 --> 6836
+collector instance we have our
+
+3120
+01:53:52,800 --> 01:53:58,639
+our sandboxing ignis vincents and so on
+
+3121
+01:53:56,0 --> 01:54:00,479
+6836 --> 6840.48
+these these already are uh define the
+
+3122
+01:53:58,639 --> 01:54:00,960
+scope of the information that go into
+
+3123
+01:54:00,479 --> 01:54:02,879
+them
+
+3124
+01:54:00,960 --> 01:54:04,960
+so we can already decide okay if we if
+
+3125
+01:54:02,880 --> 01:54:05,599
+we are on our spam collector miss
+
+3126
+01:54:04,960 --> 01:54:07,279
+vincent
+
+3127
+01:54:05,599 --> 01:54:08,880
+anything that goes in there will be
+
+3128
+01:54:07,279 --> 01:54:10,719
+related to spam so in this case we can
+
+3129
+01:54:08,880 --> 01:54:12,159
+remove these tags because we don't
+
+3130
+01:54:10,719 --> 01:54:14,880
+we don't actually want to include those
+
+3131
+01:54:12,158 --> 01:54:15,679
+just yet maybe we can keep that one
+
+3132
+01:54:14,880 --> 01:54:17,520
+because it's still
+
+3133
+01:54:15,679 --> 01:54:20,319
+a draft so that means we will do an
+
+3134
+01:54:17,520 --> 01:54:23,599
+evaluation of this famous email accuracy
+
+3135
+01:54:20,319 --> 01:54:24,238
+and then um so we have some defined
+
+3136
+01:54:23,599 --> 01:54:25,920
+taxonomy
+
+3137
+01:54:24,238 --> 01:54:27,439
+misplan on this instance we enabled for
+
+3138
+01:54:25,920 --> 01:54:29,520
+example the workflow one
+
+3139
+01:54:27,439 --> 01:54:31,39
+uh this one is maybe of interest from
+
+3140
+01:54:29,520 --> 01:54:33,280
+different organizations is
+
+3141
+01:54:31,39 --> 01:54:35,599
+a generic one about workflow uh what is
+
+3142
+01:54:33,279 --> 01:54:37,920
+the current state or other thing so
+
+3143
+01:54:35,599 --> 01:54:39,279
+don't forget uh in the initial event
+
+3144
+01:54:37,920 --> 01:54:40,560
+when we created the event we have
+
+3145
+01:54:39,279 --> 01:54:42,960
+information about
+
+3146
+01:54:40,560 --> 01:54:44,639
+uh the state and stuff like that now
+
+3147
+01:54:42,960 --> 01:54:46,158
+with this what we do is recommend to
+
+3148
+01:54:44,639 --> 01:54:46,880
+have taxonomies and you can you can
+
+3149
+01:54:46,158 --> 01:54:49,359
+really
+
+3150
+01:54:46,880 --> 01:54:51,440
+set up whatever you like and in the misp
+
+3151
+01:54:49,359 --> 01:54:52,319
+event to define the current state of
+
+3152
+01:54:51,439 --> 01:54:55,839
+this event
+
+3153
+01:54:52,319 --> 01:54:55,840
+so we keep draft from this case
+
+3154
+01:54:57,39 --> 01:55:01,840
+yeah indeed so we keep it at this and we
+
+3155
+01:55:00,238 --> 01:55:03,598
+scroll further down and we see that miss
+
+3156
+01:55:01,840 --> 01:55:05,119
+warns us about a few things first of all
+
+3157
+01:55:03,599 --> 01:55:06,639
+data is not published
+
+3158
+01:55:05,118 --> 01:55:08,639
+and second of all if we scroll a bit
+
+3159
+01:55:06,639 --> 01:55:10,239
+further down we see that mispo also
+
+3160
+01:55:08,639 --> 01:55:11,920
+tells us that there are no attributes in
+
+3161
+01:55:10,238 --> 01:55:12,399
+here so this is still an empty envelope
+
+3162
+01:55:11,920 --> 01:55:14,319
+that we
+
+3163
+01:55:12,399 --> 01:55:15,519
+are about to share so list tells us
+
+3164
+01:55:14,319 --> 01:55:18,719
+don't share this just yet
+
+3165
+01:55:15,520 --> 01:55:19,119
+fill it up with data first so at this
+
+3166
+01:55:18,719 --> 01:55:22,319
+point
+
+3167
+01:55:19,118 --> 01:55:26,0
+6919.119 --> 6926
+we can start populating the information
+
+3168
+01:55:22,319 --> 01:55:26,0
+6922.32 --> 6926
+so if you if you look at the
+
+3169
+01:55:27,439 --> 01:55:31,919
+initial document that we that we use as
+
+3170
+01:55:29,840 --> 01:55:32,800
+a starting point we see in there that we
+
+3171
+01:55:31,920 --> 01:55:35,760
+have a lot of
+
+3172
+01:55:32,800 --> 01:55:37,679
+information in there described we see
+
+3173
+01:55:35,760 --> 01:55:38,400
+for example that we are dealing with
+
+3174
+01:55:37,679 --> 01:55:40,319
+spearfishing
+
+3175
+01:55:38,399 --> 01:55:41,598
+we see that we have an email that was
+
+3176
+01:55:40,319 --> 01:55:44,880
+received at a certain
+
+3177
+01:55:41,599 --> 01:55:47,199
+point in time and we also see that
+
+3178
+01:55:44,880 --> 01:55:48,319
+we have an attacker that pretends to be
+
+3179
+01:55:47,198 --> 01:55:51,678
+um
+
+3180
+01:55:48,319 --> 01:55:54,0
+6948.32 --> 6954
+working at the ceo's uh uh daughter
+
+3181
+01:55:51,679 --> 01:55:55,440
+and sending the email address from
+
+3182
+01:55:54,0 --> 01:55:57,198
+6954 --> 6957.199
+spoofed uh
+
+3183
+01:55:55,439 --> 01:55:59,359
+the email from a spoofed email address
+
+3184
+01:55:57,198 --> 01:56:00,719
+so we can start by by describing this
+
+3185
+01:55:59,359 --> 01:56:01,759
+information by including this
+
+3186
+01:56:00,719 --> 01:56:03,279
+information
+
+3187
+01:56:01,760 --> 01:56:04,800
+so perhaps one of the things that we can
+
+3188
+01:56:03,279 --> 01:56:06,880
+take here is let's start with the most
+
+3189
+01:56:04,800 --> 01:56:09,119
+basic thing we're describing an email
+
+3190
+01:56:06,880 --> 01:56:10,880
+so let's start with an email object so
+
+3191
+01:56:09,118 --> 01:56:15,839
+we're going to add an object
+
+3192
+01:56:10,880 --> 01:56:15,840
+and we're going to select email
+
+3193
+01:56:18,479 --> 01:56:22,479
+so here we see that this is coming from
+
+3194
+01:56:20,639 --> 01:56:26,400
+the templating system where you can
+
+3195
+01:56:22,479 --> 01:56:28,79
+define uh pre different concepts with
+
+3196
+01:56:26,399 --> 01:56:30,79
+different fields that have to be then
+
+3197
+01:56:28,79 --> 01:56:31,760
+populated using this object templating
+
+3198
+01:56:30,79 --> 01:56:33,359
+system
+
+3199
+01:56:31,760 --> 01:56:35,440
+so we have a bunch of information that
+
+3200
+01:56:33,359 --> 01:56:37,39
+we can fill out here we see the spoofed
+
+3201
+01:56:35,439 --> 01:56:43,839
+address so we see a from address that we
+
+3202
+01:56:37,39 --> 01:56:43,840
+can encode
+
+3203
+01:56:45,439 --> 01:56:52,879
+okay we also have um
+
+3204
+01:56:50,399 --> 01:56:55,118
+a sample that i don't know if you if
+
+3205
+01:56:52,880 --> 01:56:58,960
+i've uploaded anywhere alex if not just
+
+3206
+01:56:55,118 --> 01:57:00,880
+pick any file for now because
+
+3207
+01:56:58,960 --> 01:57:02,319
+i think that's something i forgot to do
+
+3208
+01:57:00,880 --> 01:57:03,679
+yeah i don't know where the sample is
+
+3209
+01:57:02,319 --> 01:57:06,719
+yeah maybe we should add it
+
+3210
+01:57:03,679 --> 01:57:11,840
+yeah just put putty dot x or something
+
+3211
+01:57:06,719 --> 01:57:11,840
+if you have it
+
+3212
+01:57:12,800 --> 01:57:15,119
+oops
+
+3213
+01:57:16,639 --> 01:57:19,599
+or we can do it as a separate object we
+
+3214
+01:57:18,158 --> 01:57:21,39
+can we can just do this separately yeah
+
+3215
+01:57:19,599 --> 01:57:24,400
+we can do a separate objective
+
+3216
+01:57:21,39 --> 01:57:25,118
+yeah indeed indeed okay so what we can
+
+3217
+01:57:24,399 --> 01:57:27,118
+already
+
+3218
+01:57:25,118 --> 01:57:28,238
+describe here is we can we can still add
+
+3219
+01:57:27,118 --> 01:57:31,839
+the name of the
+
+3220
+01:57:28,238 --> 01:57:34,158
+uh attachment that we had in there
+
+3221
+01:57:31,840 --> 01:57:34,159
+um
+
+3222
+01:57:35,359 --> 01:57:39,839
+just to fast track it a bit
+
+3223
+01:57:40,639 --> 01:57:42,880
+good
+
+3224
+01:57:46,79 --> 01:57:49,760
+so we have a timestamp too which is
+
+3225
+01:57:47,679 --> 01:57:52,319
+interesting so um
+
+3226
+01:57:49,760 --> 01:57:54,239
+this one has been received as a specific
+
+3227
+01:57:52,319 --> 01:57:56,639
+so it was a third
+
+3228
+01:57:54,238 --> 01:57:58,479
+of so the first scene is basically
+
+3229
+01:57:56,639 --> 01:58:03,440
+something that you can you can really uh
+
+3230
+01:57:58,479 --> 01:58:03,439
+set up so it was the third of february
+
+3231
+01:58:03,920 --> 01:58:10,158
+we had a specific time if i'm misleading
+
+3232
+01:58:07,198 --> 01:58:11,39
+um so in this one we have uh this one
+
+3233
+01:58:10,158 --> 01:58:14,349
+has been
+
+3234
+01:58:11,39 --> 01:58:16,880
+sent on received on
+
+3235
+01:58:14,350 --> 01:58:21,840
+[Music]
+
+3236
+01:58:16,880 --> 01:58:21,840
+16 so i can
+
+3237
+01:58:27,439 --> 01:58:34,158
+we also see that that basically
+
+3238
+01:58:30,639 --> 01:58:37,199
+the attachment was spoofing
+
+3239
+01:58:34,158 --> 01:58:39,598
+the document uh
+
+3240
+01:58:37,198 --> 01:58:40,638
+about the report about the ceo's
+
+3241
+01:58:39,599 --> 01:58:42,719
+daughter's
+
+3242
+01:58:40,639 --> 01:58:44,79
+progress in school so we can pick the
+
+3243
+01:58:42,719 --> 01:58:47,279
+file name for the
+
+3244
+01:58:44,79 --> 01:58:50,639
+uh attachment and that is under the
+
+3245
+01:58:47,279 --> 01:58:50,639
+attachment section in the object
+
+3246
+01:58:54,560 --> 01:59:01,199
+good i'm just clicking it
+
+3247
+01:58:58,158 --> 01:59:02,960
+yeah it is called report.x attacks i
+
+3248
+01:59:01,198 --> 01:59:04,319
+mean maybe it's not in the text right
+
+3249
+01:59:02,960 --> 01:59:06,639
+now okay it might not be in the text
+
+3250
+01:59:04,319 --> 01:59:12,319
+might be just the original file
+
+3251
+01:59:06,639 --> 01:59:12,319
+about that so yeah report.x dot x
+
+3252
+01:59:12,800 --> 01:59:15,360
+attachment
+
+3253
+01:59:21,198 --> 01:59:24,879
+and then we also know that it was
+
+3254
+01:59:22,399 --> 01:59:24,879
+received
+
+3255
+01:59:25,39 --> 01:59:28,800
+that we have received header ip so we
+
+3256
+01:59:27,279 --> 01:59:29,198
+can include that as well that's also in
+
+3257
+01:59:28,800 --> 01:59:33,440
+the
+
+3258
+01:59:29,198 --> 01:59:33,439
+stated email it's 137.221
+
+3259
+01:59:41,599 --> 01:59:44,639
+and we even have the hostname if you
+
+3260
+01:59:42,960 --> 01:59:47,198
+want to include that that was also
+
+3261
+01:59:44,639 --> 01:59:47,199
+included in
+
+3262
+01:59:48,880 --> 01:59:51,679
+or in the report
+
+3263
+01:59:54,960 --> 01:59:59,679
+perfect so this is as you can see here
+
+3264
+01:59:58,79 --> 02:00:01,198
+we did not fill everything out because
+
+3265
+01:59:59,679 --> 02:00:03,118
+we don't know everything based on the
+
+3266
+02:00:01,198 --> 02:00:04,158
+report but we knew some of the fields we
+
+3267
+02:00:03,118 --> 02:00:05,839
+also see that
+
+3268
+02:00:04,158 --> 02:00:07,839
+each of these objects basically have
+
+3269
+02:00:05,840 --> 02:00:08,639
+some requirements and we satisfy those
+
+3270
+02:00:07,840 --> 02:00:10,560
+in this case
+
+3271
+02:00:08,639 --> 02:00:12,239
+so if you scroll all the way to the top
+
+3272
+02:00:10,560 --> 02:00:12,880
+you will see that that this object had a
+
+3273
+02:00:12,238 --> 02:00:14,559
+requirement
+
+3274
+02:00:12,880 --> 02:00:16,0
+7212.88 --> 7216
+any of those fields have to be filled
+
+3275
+02:00:14,560 --> 02:00:18,80
+we've definitely met that
+
+3276
+02:00:16,0 --> 02:00:21,359
+7216 --> 7221.36
+so we can just click submit and we can
+
+3277
+02:00:18,79 --> 02:00:21,359
+create our object in this case
+
+3278
+02:00:23,198 --> 02:00:26,799
+so here we see mrs telling us if we
+
+3279
+02:00:25,359 --> 02:00:27,519
+create this object that's what it will
+
+3280
+02:00:26,800 --> 02:00:28,880
+look like
+
+3281
+02:00:27,520 --> 02:00:30,719
+so we have in this case created our
+
+3282
+02:00:28,880 --> 02:00:31,359
+object and now it is attached to the
+
+3283
+02:00:30,719 --> 02:00:33,840
+event and
+
+3284
+02:00:31,359 --> 02:00:34,960
+suddenly stuff happened here so we see
+
+3285
+02:00:33,840 --> 02:00:37,119
+that each of these
+
+3286
+02:00:34,960 --> 02:00:38,480
+attributes already start correlating
+
+3287
+02:00:37,118 --> 02:00:40,799
+with existing events
+
+3288
+02:00:38,479 --> 02:00:42,718
+now we read this uh this little exercise
+
+3289
+02:00:40,800 --> 02:00:44,159
+before we didn't correlate with some of
+
+3290
+02:00:42,719 --> 02:00:46,880
+those previous events
+
+3291
+02:00:44,158 --> 02:00:50,238
+but normally uh if this was a real case
+
+3292
+02:00:46,880 --> 02:00:50,239
+if you get a correlation
+
+3293
+02:00:50,319 --> 02:00:54,399
+that is either something very similar
+
+3294
+02:00:52,319 --> 02:00:56,639
+that already happened before or is it
+
+3295
+02:00:54,399 --> 02:00:58,719
+something that simply
+
+3296
+02:00:56,639 --> 02:01:00,400
+might be a coincidence but it's still
+
+3297
+02:00:58,719 --> 02:01:02,239
+close for investigation
+
+3298
+02:01:00,399 --> 02:01:04,559
+to check is this something that might
+
+3299
+02:01:02,238 --> 02:01:07,439
+help me bootstrap my investigation
+
+3300
+02:01:04,560 --> 02:01:08,719
+or is it just noise that is not maybe a
+
+3301
+02:01:07,439 --> 02:01:09,279
+side note because we have often the
+
+3302
+02:01:08,719 --> 02:01:12,560
+questions
+
+3303
+02:01:09,279 --> 02:01:14,319
+um when you create such object in
+
+3304
+02:01:12,560 --> 02:01:15,840
+you see that can be cumbersome to create
+
+3305
+02:01:14,319 --> 02:01:17,439
+it manually
+
+3306
+02:01:15,840 --> 02:01:20,79
+so don't forget that everything that we
+
+3307
+02:01:17,439 --> 02:01:22,479
+do right now can be done through the api
+
+3308
+02:01:20,79 --> 02:01:23,519
+so you can use pymisp automatically do
+
+3309
+02:01:22,479 --> 02:01:26,319
+it and so on so
+
+3310
+02:01:23,520 --> 02:01:27,840
+what we show there um i think if you
+
+3311
+02:01:26,319 --> 02:01:29,599
+think on the api level
+
+3312
+02:01:27,840 --> 02:01:31,119
+it can be done automatically so if you
+
+3313
+02:01:29,599 --> 02:01:33,119
+have two that are extracting emails
+
+3314
+02:01:31,118 --> 02:01:35,39
+automatically from the
+
+3315
+02:01:33,118 --> 02:01:36,559
+pc mailbox whatever you can
+
+3316
+02:01:35,39 --> 02:01:37,760
+automatically do it in mist
+
+3317
+02:01:36,560 --> 02:01:39,679
+we just show the complete process
+
+3318
+02:01:37,760 --> 02:01:41,39
+manually but you can never mix things
+
+3319
+02:01:39,679 --> 02:01:42,399
+for some event
+
+3320
+02:01:41,39 --> 02:01:44,158
+maybe some might be created
+
+3321
+02:01:42,399 --> 02:01:46,638
+automatically and then update it
+
+3322
+02:01:44,158 --> 02:01:47,839
+manually and so on
+
+3323
+02:01:46,639 --> 02:01:49,520
+something else that might be interesting
+
+3324
+02:01:47,840 --> 02:01:50,960
+here at this point is we've encoded this
+
+3325
+02:01:49,520 --> 02:01:54,560
+object and we look at it
+
+3326
+02:01:50,960 --> 02:01:56,880
+and perhaps we we might want to
+
+3327
+02:01:54,560 --> 02:01:58,400
+to change the distribution settings
+
+3328
+02:01:56,880 --> 02:01:59,279
+based on the different data points that
+
+3329
+02:01:58,399 --> 02:02:02,238
+we have in there
+
+3330
+02:01:59,279 --> 02:02:04,79
+so most of these such as the malicious
+
+3331
+02:02:02,238 --> 02:02:05,759
+host that email is sent from
+
+3332
+02:02:04,79 --> 02:02:07,279
+are technical information that we can
+
+3333
+02:02:05,760 --> 02:02:10,320
+share with the broader community
+
+3334
+02:02:07,279 --> 02:02:12,399
+but perhaps the name of the
+
+3335
+02:02:10,319 --> 02:02:13,599
+school that our ceo's daughter attends
+
+3336
+02:02:12,399 --> 02:02:15,118
+is something that we don't need to share
+
+3337
+02:02:13,599 --> 02:02:17,679
+with the entire community
+
+3338
+02:02:15,118 --> 02:02:20,0
+7335.119 --> 7340
+so we could reduce the distribution of
+
+3339
+02:02:17,679 --> 02:02:21,760
+that individual attribute in this object
+
+3340
+02:02:20,0 --> 02:02:23,520
+7340 --> 7343.52
+so that we keep that for example only
+
+3341
+02:02:21,760 --> 02:02:24,639
+for our own organization and for our own
+
+3342
+02:02:23,520 --> 02:02:26,0
+7343.52 --> 7346
+internal records
+
+3343
+02:02:24,639 --> 02:02:27,599
+so one of the things you can do in this
+
+3344
+02:02:26,0 --> 02:02:28,158
+7346 --> 7348.159
+case is you can edit that individual
+
+3345
+02:02:27,599 --> 02:02:32,960
+attribute
+
+3346
+02:02:28,158 --> 02:02:34,799
+so the from address in the object
+
+3347
+02:02:32,960 --> 02:02:36,399
+and you can set a distribution level to
+
+3348
+02:02:34,800 --> 02:02:38,560
+your organization only
+
+3349
+02:02:36,399 --> 02:02:40,479
+in this case once we release the uh the
+
+3350
+02:02:38,560 --> 02:02:43,440
+event to a broader audience
+
+3351
+02:02:40,479 --> 02:02:45,198
+it will keep this individual attribute
+
+3352
+02:02:43,439 --> 02:02:46,0
+7363.44 --> 7366
+for an organization and it will not
+
+3353
+02:02:45,198 --> 02:02:49,598
+share it out with
+
+3354
+02:02:46,0 --> 02:02:51,279
+7366 --> 7371.28
+uh with other constituencies okay
+
+3355
+02:02:49,599 --> 02:02:53,39
+so some other stuff that happened at
+
+3356
+02:02:51,279 --> 02:02:54,479
+this point we see that
+
+3357
+02:02:53,39 --> 02:02:55,679
+several of you are creating events so
+
+3358
+02:02:54,479 --> 02:02:57,359
+that's great the correlation account
+
+3359
+02:02:55,679 --> 02:02:59,440
+really went up all of the sudden
+
+3360
+02:02:57,359 --> 02:03:00,479
+so it's good to see something else that
+
+3361
+02:02:59,439 --> 02:03:03,439
+happened at this point
+
+3362
+02:03:00,479 --> 02:03:05,198
+is uh is the event itself got correlated
+
+3363
+02:03:03,439 --> 02:03:06,158
+to other events as well so if you scroll
+
+3364
+02:03:05,198 --> 02:03:07,598
+up all the way
+
+3365
+02:03:06,158 --> 02:03:09,519
+we see that the attributes that we've
+
+3366
+02:03:07,599 --> 02:03:11,360
+added are also showing us what other
+
+3367
+02:03:09,520 --> 02:03:12,159
+events we're correlating in so this is a
+
+3368
+02:03:11,359 --> 02:03:13,598
+summary of
+
+3369
+02:03:12,158 --> 02:03:15,359
+all the individual attributes
+
+3370
+02:03:13,599 --> 02:03:17,119
+correlations from the event
+
+3371
+02:03:15,359 --> 02:03:18,639
+that means that if you have if this
+
+3372
+02:03:17,118 --> 02:03:20,79
+object is correlating or
+
+3373
+02:03:18,639 --> 02:03:21,920
+these attributes within the object are
+
+3374
+02:03:20,79 --> 02:03:23,840
+correlating to it with a certain event
+
+3375
+02:03:21,920 --> 02:03:25,359
+and certain other objects are
+
+3376
+02:03:23,840 --> 02:03:27,119
+correlating with other events
+
+3377
+02:03:25,359 --> 02:03:29,359
+then this would be a full summary of all
+
+3378
+02:03:27,118 --> 02:03:31,920
+the events that you're correlating with
+
+3379
+02:03:29,359 --> 02:03:33,198
+you can also draw a graph out of that if
+
+3380
+02:03:31,920 --> 02:03:35,199
+you click on the correlation graph you
+
+3381
+02:03:33,198 --> 02:03:37,118
+will see how the events are interlinked
+
+3382
+02:03:35,198 --> 02:03:38,719
+and you can further explore this by
+
+3383
+02:03:37,118 --> 02:03:41,519
+selecting any of the notes
+
+3384
+02:03:38,719 --> 02:03:42,639
+and pressing x on that to further expand
+
+3385
+02:03:41,520 --> 02:03:46,159
+it with
+
+3386
+02:03:42,639 --> 02:03:46,159
+with it with its own correlations
+
+3387
+02:03:46,960 --> 02:03:52,78
+okay let's go back to event
+
+3388
+02:03:52,238 --> 02:03:56,399
+yeah i don't think we have a lot of
+
+3389
+02:03:55,679 --> 02:03:58,399
+correlations
+
+3390
+02:03:56,399 --> 02:03:59,679
+there for the other events they're all
+
+3391
+02:03:58,399 --> 02:04:02,960
+the same
+
+3392
+02:03:59,679 --> 02:04:03,920
+uh okay now going back to a little
+
+3393
+02:04:02,960 --> 02:04:06,319
+example uh
+
+3394
+02:04:03,920 --> 02:04:07,440
+we have now created four attributes all
+
+3395
+02:04:06,319 --> 02:04:10,319
+together out of
+
+3396
+02:04:07,439 --> 02:04:11,759
+uh of the object template but we could
+
+3397
+02:04:10,319 --> 02:04:12,880
+have done this differently as well what
+
+3398
+02:04:11,760 --> 02:04:14,800
+we could have done
+
+3399
+02:04:12,880 --> 02:04:16,480
+is we could also have created those
+
+3400
+02:04:14,800 --> 02:04:17,39
+attributes individually and added those
+
+3401
+02:04:16,479 --> 02:04:20,319
+to the
+
+3402
+02:04:17,39 --> 02:04:21,920
+uh to the um event directly
+
+3403
+02:04:20,319 --> 02:04:24,319
+so one of the things that we can do now
+
+3404
+02:04:21,920 --> 02:04:25,920
+is we can go back to our report and
+
+3405
+02:04:24,319 --> 02:04:27,359
+tackle the next thing that is described
+
+3406
+02:04:25,920 --> 02:04:28,480
+there and let's do it slightly
+
+3407
+02:04:27,359 --> 02:04:31,198
+differently
+
+3408
+02:04:28,479 --> 02:04:31,759
+so we also see that basically uh the
+
+3409
+02:04:31,198 --> 02:04:34,479
+person
+
+3410
+02:04:31,760 --> 02:04:36,840
+uh that this is impersonated is also
+
+3411
+02:04:34,479 --> 02:04:40,959
+described so that is basically
+
+3412
+02:04:36,840 --> 02:04:40,960
+um in this case
+
+3413
+02:04:41,118 --> 02:04:45,359
+john doe the teacher of the student so
+
+3414
+02:04:43,520 --> 02:04:47,40
+let's just create a personal object and
+
+3415
+02:04:45,359 --> 02:04:50,78
+describe that
+
+3416
+02:04:47,39 --> 02:04:53,519
+so what we can do now is instead of
+
+3417
+02:04:50,78 --> 02:04:54,158
+directly describing it as an object we
+
+3418
+02:04:53,520 --> 02:04:57,520
+can first
+
+3419
+02:04:54,158 --> 02:04:58,78
+add those different fields at least a
+
+3420
+02:04:57,520 --> 02:05:00,0
+7497.52 --> 7500
+name
+
+3421
+02:04:58,78 --> 02:05:01,599
+as individual attributes so let's let's
+
+3422
+02:05:00,0 --> 02:05:03,279
+7500 --> 7503.28
+see how adding individual attributes
+
+3423
+02:05:01,599 --> 02:05:05,39
+work so we click on the little plus icon
+
+3424
+02:05:03,279 --> 02:05:08,880
+above the attribute list
+
+3425
+02:05:05,39 --> 02:05:08,880
+and we simply select category person
+
+3426
+02:05:09,439 --> 02:05:13,598
+and from person we select first name
+
+3427
+02:05:11,439 --> 02:05:15,39
+first name is john
+
+3428
+02:05:13,599 --> 02:05:17,39
+and here we can already define is this
+
+3429
+02:05:15,39 --> 02:05:19,198
+an indicator do we want to
+
+3430
+02:05:17,39 --> 02:05:21,599
+set the for intrusion detection system
+
+3431
+02:05:19,198 --> 02:05:22,879
+flag no definitely not this in itself is
+
+3432
+02:05:21,599 --> 02:05:24,880
+not an indicator
+
+3433
+02:05:22,880 --> 02:05:26,719
+in fact we want to also disable
+
+3434
+02:05:24,880 --> 02:05:27,679
+correlation on this as this is a pretty
+
+3435
+02:05:26,719 --> 02:05:31,840
+common
+
+3436
+02:05:27,679 --> 02:05:34,719
+uh name that is definitely not something
+
+3437
+02:05:31,840 --> 02:05:36,0
+7531.84 --> 7536
+to we don't need a comment for enough
+
+3438
+02:05:34,719 --> 02:05:38,800
+but now we're going to convert it into
+
+3439
+02:05:36,0 --> 02:05:41,439
+7536 --> 7541.44
+an object anyway
+
+3440
+02:05:38,800 --> 02:05:42,880
+uh so what we can do is we can also
+
+3441
+02:05:41,439 --> 02:05:44,158
+disable correlation on this we don't
+
+3442
+02:05:42,880 --> 02:05:47,520
+want to correlate on john
+
+3443
+02:05:44,158 --> 02:05:51,39
+okay okay doesn't matter
+
+3444
+02:05:47,520 --> 02:05:53,360
+actually we can do it uh
+
+3445
+02:05:51,39 --> 02:05:55,279
+the same thing for the last name though
+
+3446
+02:05:53,359 --> 02:05:57,198
+and we can basically say that this is
+
+3447
+02:05:55,279 --> 02:05:58,960
+now
+
+3448
+02:05:57,198 --> 02:06:00,399
+last name now we've added these two
+
+3449
+02:05:58,960 --> 02:06:01,599
+things in there now the problem with
+
+3450
+02:06:00,399 --> 02:06:03,679
+this is if we just had
+
+3451
+02:06:01,599 --> 02:06:04,719
+attributes instead of objects is we
+
+3452
+02:06:03,679 --> 02:06:06,399
+don't really see that
+
+3453
+02:06:04,719 --> 02:06:08,78
+john and do in this case are the first
+
+3454
+02:06:06,399 --> 02:06:10,559
+name and last name belong together
+
+3455
+02:06:08,78 --> 02:06:12,238
+so if i were to describe several people
+
+3456
+02:06:10,560 --> 02:06:13,599
+in the same event you would have a list
+
+3457
+02:06:12,238 --> 02:06:17,118
+of first names and a list of
+
+3458
+02:06:13,599 --> 02:06:17,520
+last names with no connection between
+
+3459
+02:06:17,118 --> 02:06:20,399
+the
+
+3460
+02:06:17,520 --> 02:06:21,920
+two things so it's better to use objects
+
+3461
+02:06:20,399 --> 02:06:24,399
+in general whenever you're describing
+
+3462
+02:06:21,920 --> 02:06:26,158
+multiple aspects of the same thing
+
+3463
+02:06:24,399 --> 02:06:27,920
+obviously if you just have a list of
+
+3464
+02:06:26,158 --> 02:06:29,359
+file hashes that you got from a feed and
+
+3465
+02:06:27,920 --> 02:06:30,719
+you just encode those and you don't have
+
+3466
+02:06:29,359 --> 02:06:32,0
+7589.36 --> 7592
+any other information with them you
+
+3467
+02:06:30,719 --> 02:06:33,279
+might as well just create flat
+
+3468
+02:06:32,0 --> 02:06:34,479
+7592 --> 7594.48
+attributes out of them
+
+3469
+02:06:33,279 --> 02:06:36,880
+because there is nothing else to
+
+3470
+02:06:34,479 --> 02:06:38,399
+describe from your perspective
+
+3471
+02:06:36,880 --> 02:06:39,679
+but even in that case it's arguable
+
+3472
+02:06:38,399 --> 02:06:40,799
+whether you don't want to start an
+
+3473
+02:06:39,679 --> 02:06:42,399
+object
+
+3474
+02:06:40,800 --> 02:06:44,0
+7600.8 --> 7604
+from the get go but what we can do in
+
+3475
+02:06:42,399 --> 02:06:45,598
+this case if we did start with this way
+
+3476
+02:06:44,0 --> 02:06:47,520
+7604 --> 7607.52
+or if you receive information in this
+
+3477
+02:06:45,599 --> 02:06:48,719
+format or your tools parse the data out
+
+3478
+02:06:47,520 --> 02:06:50,560
+in this format is
+
+3479
+02:06:48,719 --> 02:06:51,920
+you can select those two attributes by
+
+3480
+02:06:50,560 --> 02:06:52,960
+clicking the little check marks next
+
+3481
+02:06:51,920 --> 02:06:54,800
+there are little
+
+3482
+02:06:52,960 --> 02:06:56,560
+tick boxes next to them and then
+
+3483
+02:06:54,800 --> 02:06:58,79
+clicking on group selected attributes
+
+3484
+02:06:56,560 --> 02:06:59,920
+into an object
+
+3485
+02:06:58,78 --> 02:07:01,599
+and here miss will propose okay these
+
+3486
+02:06:59,920 --> 02:07:03,440
+are the different object templates that
+
+3487
+02:07:01,599 --> 02:07:04,719
+satisfy
+
+3488
+02:07:03,439 --> 02:07:06,960
+the list of attributes that you've
+
+3489
+02:07:04,719 --> 02:07:07,920
+selected there's a person object that we
+
+3490
+02:07:06,960 --> 02:07:11,118
+can use so let's
+
+3491
+02:07:07,920 --> 02:07:11,118
+just pick that one for now
+
+3492
+02:07:11,599 --> 02:07:15,199
+so here we see if we were to combine
+
+3493
+02:07:13,679 --> 02:07:16,800
+these two things they would be merged
+
+3494
+02:07:15,198 --> 02:07:19,198
+into an object
+
+3495
+02:07:16,800 --> 02:07:20,560
+uh that is fine with us we see first
+
+3496
+02:07:19,198 --> 02:07:23,359
+name will become
+
+3497
+02:07:20,560 --> 02:07:24,480
+the the first name of the object last
+
+3498
+02:07:23,359 --> 02:07:27,839
+name the last name
+
+3499
+02:07:24,479 --> 02:07:27,839
+so let's merge it
+
+3500
+02:07:28,960 --> 02:07:34,239
+now we basically have a personality now
+
+3501
+02:07:32,238 --> 02:07:36,718
+we also know that this person that we're
+
+3502
+02:07:34,238 --> 02:07:38,638
+dealing with here is impersonating uh
+
+3503
+02:07:36,719 --> 02:07:40,560
+the teacher of the ceo's or daughter so
+
+3504
+02:07:38,639 --> 02:07:42,400
+the same person impersonated person is a
+
+3505
+02:07:40,560 --> 02:07:44,480
+teacher of the of the ceo's author
+
+3506
+02:07:42,399 --> 02:07:45,679
+so we added the object and we also see
+
+3507
+02:07:44,479 --> 02:07:48,78
+that there is a um
+
+3508
+02:07:45,679 --> 02:07:50,239
+that we can add just another text field
+
+3509
+02:07:48,78 --> 02:07:53,439
+yeah just text field works
+
+3510
+02:07:50,238 --> 02:07:54,879
+where we can describe it i just want to
+
+3511
+02:07:53,439 --> 02:07:57,598
+first disable the correlation because
+
+3512
+02:07:54,880 --> 02:07:57,599
+different means
+
+3513
+02:08:06,840 --> 02:08:10,800
+okay
+
+3514
+02:08:08,238 --> 02:08:12,319
+yeah that works and we just add a text
+
+3515
+02:08:10,800 --> 02:08:13,440
+description of the identity of the
+
+3516
+02:08:12,319 --> 02:08:22,319
+person we can just say
+
+3517
+02:08:13,439 --> 02:08:26,0
+7693.44 --> 7706
+teacher of the ceo's daughter
+
+3518
+02:08:22,319 --> 02:08:27,439
+okay now we're done we have now added
+
+3519
+02:08:26,0 --> 02:08:28,960
+7706 --> 7708.96
+the additional attribute and now now we
+
+3520
+02:08:27,439 --> 02:08:31,118
+know what this object is actually about
+
+3521
+02:08:28,960 --> 02:08:32,880
+without having a description in there
+
+3522
+02:08:31,118 --> 02:08:34,960
+but we still just have an email and a
+
+3523
+02:08:32,880 --> 02:08:36,239
+person described in here but we don't
+
+3524
+02:08:34,960 --> 02:08:37,760
+know anything else we
+
+3525
+02:08:36,238 --> 02:08:39,279
+don't know that this email is proofing
+
+3526
+02:08:37,760 --> 02:08:41,119
+to be that person so we should add a
+
+3527
+02:08:39,279 --> 02:08:43,118
+relationship between the two
+
+3528
+02:08:41,118 --> 02:08:44,639
+now for this we can switch over to the
+
+3529
+02:08:43,118 --> 02:08:46,719
+event graph view
+
+3530
+02:08:44,639 --> 02:08:48,400
+so that is a little bit further up this
+
+3531
+02:08:46,719 --> 02:08:50,239
+one allows us to create
+
+3532
+02:08:48,399 --> 02:08:52,0
+7728.4 --> 7732
+connected graphs out of our individual
+
+3533
+02:08:50,238 --> 02:08:54,559
+data points so we see that we have
+
+3534
+02:08:52,0 --> 02:08:55,279
+7732 --> 7735.28
+two unreferenced objects so we explode
+
+3535
+02:08:54,560 --> 02:08:58,639
+that mode
+
+3536
+02:08:55,279 --> 02:09:00,719
+by pressing x and we can we can draw
+
+3537
+02:08:58,639 --> 02:09:02,639
+an edge between those two nodes by
+
+3538
+02:09:00,719 --> 02:09:04,319
+clicking edit and add reference
+
+3539
+02:09:02,639 --> 02:09:05,760
+and drawing a line between the two from
+
+3540
+02:09:04,319 --> 02:09:08,880
+the
+
+3541
+02:09:05,760 --> 02:09:08,880
+email to the person
+
+3542
+02:09:09,39 --> 02:09:12,880
+when you do that miss will propose a
+
+3543
+02:09:11,118 --> 02:09:15,39
+list of relationship
+
+3544
+02:09:12,880 --> 02:09:16,480
+types between these two two different
+
+3545
+02:09:15,39 --> 02:09:18,158
+nodes
+
+3546
+02:09:16,479 --> 02:09:19,439
+there is also a custom one there so if
+
+3547
+02:09:18,158 --> 02:09:21,198
+you don't want to select anything from
+
+3548
+02:09:19,439 --> 02:09:24,559
+the list that is fine too but for now
+
+3549
+02:09:21,198 --> 02:09:26,238
+we can just use the impersonates
+
+3550
+02:09:24,560 --> 02:09:28,79
+relationship which already exists in the
+
+3551
+02:09:26,238 --> 02:09:31,39
+default library
+
+3552
+02:09:28,78 --> 02:09:31,39
+just click on submit
+
+3553
+02:09:31,760 --> 02:09:34,880
+and now we have a relationship set
+
+3554
+02:09:33,198 --> 02:09:36,78
+between those two so we started telling
+
+3555
+02:09:34,880 --> 02:09:37,520
+our story by basically having a
+
+3556
+02:09:36,78 --> 02:09:40,399
+connected graph between the
+
+3557
+02:09:37,520 --> 02:09:40,880
+these two points now let's further look
+
+3558
+02:09:40,399 --> 02:09:43,920
+at our
+
+3559
+02:09:40,880 --> 02:09:47,520
+original email and see what else we can
+
+3560
+02:09:43,920 --> 02:09:49,520
+get out of the text from there
+
+3561
+02:09:47,520 --> 02:09:51,199
+we also see that the malicious file was
+
+3562
+02:09:49,520 --> 02:09:54,0
+7789.52 --> 7794
+contained in the email as
+
+3563
+02:09:51,198 --> 02:09:55,519
+well as an attachment so let's upload an
+
+3564
+02:09:54,0 --> 02:09:57,198
+7794 --> 7797.199
+attachment now to ms
+
+3565
+02:09:55,520 --> 02:09:58,880
+i hope you have put in the text there or
+
+3566
+02:09:57,198 --> 02:10:01,359
+something because i forgot to clearly
+
+3567
+02:09:58,880 --> 02:10:01,359
+i've
+
+3568
+02:10:02,880 --> 02:10:07,279
+so as an attachment and this is where
+
+3569
+02:10:05,439 --> 02:10:08,719
+things become a little bit tricky
+
+3570
+02:10:07,279 --> 02:10:10,158
+uh there's there's a quick question
+
+3571
+02:10:08,719 --> 02:10:11,920
+there on the chat i'll just quickly
+
+3572
+02:10:10,158 --> 02:10:14,78
+answer that then we can get back to this
+
+3573
+02:10:11,920 --> 02:10:15,679
+where can i create a reference if you go
+
+3574
+02:10:14,78 --> 02:10:17,519
+above the attribute list there is an
+
+3575
+02:10:15,679 --> 02:10:18,960
+event graph button if you click on that
+
+3576
+02:10:17,520 --> 02:10:20,719
+you get the event graph
+
+3577
+02:10:18,960 --> 02:10:22,800
+and on the top left side you click on
+
+3578
+02:10:20,719 --> 02:10:24,239
+edit and then add reference
+
+3579
+02:10:22,800 --> 02:10:26,639
+like i can show it again nowadays oh
+
+3580
+02:10:24,238 --> 02:10:29,279
+yeah that's a bit better here
+
+3581
+02:10:26,639 --> 02:10:30,319
+so have this kind of gray bar there with
+
+3582
+02:10:29,279 --> 02:10:32,719
+even graph
+
+3583
+02:10:30,319 --> 02:10:33,679
+so you can basically collapse or expand
+
+3584
+02:10:32,719 --> 02:10:36,880
+it
+
+3585
+02:10:33,679 --> 02:10:37,359
+uh and then there you can select one of
+
+3586
+02:10:36,880 --> 02:10:40,480
+those
+
+3587
+02:10:37,359 --> 02:10:41,39
+reference objects you press x to expand
+
+3588
+02:10:40,479 --> 02:10:44,638
+all those
+
+3589
+02:10:41,39 --> 02:10:47,679
+reference objects then you can just
+
+3590
+02:10:44,639 --> 02:10:51,39
+select one object that you want
+
+3591
+02:10:47,679 --> 02:10:53,39
+to add and then you can edit add the
+
+3592
+02:10:51,39 --> 02:10:54,78
+references and then you can add specific
+
+3593
+02:10:53,39 --> 02:10:55,599
+references
+
+3594
+02:10:54,78 --> 02:10:56,960
+in case it doesn't make sense to make a
+
+3595
+02:10:55,599 --> 02:10:57,760
+second reference but that's basically
+
+3596
+02:10:56,960 --> 02:10:59,279
+how you do it
+
+3597
+02:10:57,760 --> 02:11:01,280
+then you select your relationship type
+
+3598
+02:10:59,279 --> 02:11:03,759
+and you can add your reference
+
+3599
+02:11:01,279 --> 02:11:04,479
+uh it's not the only way to do it
+
+3600
+02:11:03,760 --> 02:11:06,79
+there's a
+
+3601
+02:11:04,479 --> 02:11:07,198
+i would say current-based representation
+
+3602
+02:11:06,78 --> 02:11:09,118
+where you can do it because we can't
+
+3603
+02:11:07,198 --> 02:11:11,519
+even show it
+
+3604
+02:11:09,118 --> 02:11:13,39
+so you have to go it's it's much more
+
+3605
+02:11:11,520 --> 02:11:16,480
+difficult to understand what happens
+
+3606
+02:11:13,39 --> 02:11:18,238
+yeah so so there the referendum that you
+
+3607
+02:11:16,479 --> 02:11:20,959
+created through the even graph
+
+3608
+02:11:18,238 --> 02:11:22,479
+is represented here so you see that this
+
+3609
+02:11:20,960 --> 02:11:24,399
+object
+
+3610
+02:11:22,479 --> 02:11:25,598
+has a reference so from email to
+
+3611
+02:11:24,399 --> 02:11:27,39
+impersonate
+
+3612
+02:11:25,599 --> 02:11:28,960
+and here's the opposite relationship
+
+3613
+02:11:27,39 --> 02:11:30,399
+that you can describe the reference buy
+
+3614
+02:11:28,960 --> 02:11:32,560
+and you have the reference buy
+
+3615
+02:11:30,399 --> 02:11:33,679
+on this object so another niche mention
+
+3616
+02:11:32,560 --> 02:11:37,840
+is i think
+
+3617
+02:11:33,679 --> 02:11:40,0
+7893.679 --> 7900
+less uh i would say 54 for
+
+3618
+02:11:37,840 --> 02:11:41,199
+and so on but sometimes you just when
+
+3619
+02:11:40,0 --> 02:11:43,39
+7900 --> 7903.04
+you are in the object you just want to
+
+3620
+02:11:41,198 --> 02:11:47,39
+see if you have any reference or
+
+3621
+02:11:43,39 --> 02:11:47,39
+a sign and you can quickly see that
+
+3622
+02:11:48,639 --> 02:11:54,880
+so let's add an attachment now
+
+3623
+02:11:53,39 --> 02:11:56,319
+and upload the sample that was uh
+
+3624
+02:11:54,880 --> 02:11:59,118
+included in the
+
+3625
+02:11:56,319 --> 02:12:00,559
+original uh email so we just click on
+
+3626
+02:11:59,118 --> 02:12:01,839
+add attachment
+
+3627
+02:12:00,560 --> 02:12:04,880
+we select the file that you want to
+
+3628
+02:12:01,840 --> 02:12:05,599
+upload yeah so for the attachment uh in
+
+3629
+02:12:04,880 --> 02:12:07,279
+this you have
+
+3630
+02:12:05,599 --> 02:12:08,400
+really two models you have the model
+
+3631
+02:12:07,279 --> 02:12:09,679
+that an attachment is basically
+
+3632
+02:12:08,399 --> 02:12:12,479
+something completely
+
+3633
+02:12:09,679 --> 02:12:13,118
+uh being safe and you can basically
+
+3634
+02:12:12,479 --> 02:12:16,479
+share it
+
+3635
+02:12:13,118 --> 02:12:17,359
+uh directly so for example you have
+
+3636
+02:12:16,479 --> 02:12:20,399
+attachment like
+
+3637
+02:12:17,359 --> 02:12:21,920
+reports and stuff in our case um
+
+3638
+02:12:20,399 --> 02:12:23,598
+what we want to share here it's a
+
+3639
+02:12:21,920 --> 02:12:25,760
+malicious number um
+
+3640
+02:12:23,599 --> 02:12:27,199
+so and that's i will take i will take
+
+3641
+02:12:25,760 --> 02:12:30,560
+which one
+
+3642
+02:12:27,198 --> 02:12:30,559
+take a sample somewhere
+
+3643
+02:12:32,840 --> 02:12:36,560
+um
+
+3644
+02:12:34,639 --> 02:12:38,78
+press on one what we are interesting
+
+3645
+02:12:36,560 --> 02:12:42,320
+there
+
+3646
+02:12:38,78 --> 02:12:44,158
+uh by the windows executables
+
+3647
+02:12:42,319 --> 02:12:45,599
+and then you have to select if the
+
+3648
+02:12:44,158 --> 02:12:46,799
+sample is malicious if you don't do
+
+3649
+02:12:45,599 --> 02:12:48,239
+anything
+
+3650
+02:12:46,800 --> 02:12:50,880
+what it will be it will be something
+
+3651
+02:12:48,238 --> 02:12:51,519
+like same uh report a pdf report
+
+3652
+02:12:50,880 --> 02:12:54,78
+something that's
+
+3653
+02:12:51,520 --> 02:12:55,599
+like supporting you in contextualization
+
+3654
+02:12:54,78 --> 02:12:56,238
+could be a screenshot for example things
+
+3655
+02:12:55,599 --> 02:12:58,400
+like that
+
+3656
+02:12:56,238 --> 02:12:59,279
+but if you share a sample you have to
+
+3657
+02:12:58,399 --> 02:13:02,158
+select
+
+3658
+02:12:59,279 --> 02:13:03,920
+uh it's a sample because like that mist
+
+3659
+02:13:02,158 --> 02:13:05,679
+will encrypt
+
+3660
+02:13:03,920 --> 02:13:07,679
+and hash a file so that means you have a
+
+3661
+02:13:05,679 --> 02:13:08,719
+zip file encrypted with a default
+
+3662
+02:13:07,679 --> 02:13:11,679
+password
+
+3663
+02:13:08,719 --> 02:13:12,560
+infected but i got to avoid classical
+
+3664
+02:13:11,679 --> 02:13:15,359
+mistake of
+
+3665
+02:13:12,560 --> 02:13:17,360
+clicking on a link executing binaries on
+
+3666
+02:13:15,359 --> 02:13:18,799
+your analysis machines and so on and so
+
+3667
+02:13:17,359 --> 02:13:20,639
+on you don't want to do that so
+
+3668
+02:13:18,800 --> 02:13:22,0
+7998.8 --> 8002
+if it's malicious always click malware
+
+3669
+02:13:20,639 --> 02:13:23,440
+samples
+
+3670
+02:13:22,0 --> 02:13:25,599
+8002 --> 8005.599
+then you have one below which will
+
+3671
+02:13:23,439 --> 02:13:27,919
+advance the extraction
+
+3672
+02:13:25,599 --> 02:13:30,0
+8005.599 --> 8010
+uh mist can do a lot of things behind
+
+3673
+02:13:27,920 --> 02:13:31,599
+the scene when you receive a file in
+
+3674
+02:13:30,0 --> 02:13:34,800
+8010 --> 8014.8
+this case it's a window
+
+3675
+02:13:31,599 --> 02:13:36,480
+of windows portable executable files so
+
+3676
+02:13:34,800 --> 02:13:37,920
+we have particular advanced extraction
+
+3677
+02:13:36,479 --> 02:13:40,158
+for those files and we can
+
+3678
+02:13:37,920 --> 02:13:41,199
+expand completely the files including
+
+3679
+02:13:40,158 --> 02:13:44,799
+resources
+
+3680
+02:13:41,198 --> 02:13:48,0
+8021.199 --> 8028
+code segment and stuff again
+
+3681
+02:13:44,800 --> 02:13:48,0
+8024.8 --> 8028
+so i will upload the files
+
+3682
+02:13:53,359 --> 02:13:57,439
+okay in this case this one was just like
+
+3683
+02:13:55,39 --> 02:14:00,78
+a very simple one
+
+3684
+02:13:57,439 --> 02:14:01,279
+so in this case what do we have we have
+
+3685
+02:14:00,78 --> 02:14:04,319
+an object
+
+3686
+02:14:01,279 --> 02:14:06,559
+with the file names the size invite and
+
+3687
+02:14:04,319 --> 02:14:08,158
+then the hash file so automatically miss
+
+3688
+02:14:06,560 --> 02:14:08,880
+will do the hashing of the different
+
+3689
+02:14:08,158 --> 02:14:11,519
+files
+
+3690
+02:14:08,880 --> 02:14:12,0
+8048.88 --> 8052
+the sample itself is attached so you can
+
+3691
+02:14:11,520 --> 02:14:14,880
+basically
+
+3692
+02:14:12,0 --> 02:14:16,880
+8052 --> 8056.88
+use it and some additional ones like ssd
+
+3693
+02:14:14,880 --> 02:14:18,880
+for example my type are automatically
+
+3694
+02:14:16,880 --> 02:14:20,480
+extracted
+
+3695
+02:14:18,880 --> 02:14:22,239
+just maybe for the sake of it i will
+
+3696
+02:14:20,479 --> 02:14:25,359
+just take maybe another
+
+3697
+02:14:22,238 --> 02:14:25,839
+binary just for showing you what could
+
+3698
+02:14:25,359 --> 02:14:28,479
+happen
+
+3699
+02:14:25,840 --> 02:14:30,0
+8065.84 --> 8070
+with other binaries maybe that's for
+
+3700
+02:14:28,479 --> 02:14:32,559
+later for different events so
+
+3701
+02:14:30,0 --> 02:14:33,439
+8070 --> 8073.44
+okay the objectives because it's easier
+
+3702
+02:14:32,560 --> 02:14:35,360
+to see for the
+
+3703
+02:14:33,439 --> 02:14:37,359
+photograph that's fine too you can show
+
+3704
+02:14:35,359 --> 02:14:39,39
+it afterwards yeah
+
+3705
+02:14:37,359 --> 02:14:41,39
+okay so now we have this again this kind
+
+3706
+02:14:39,39 --> 02:14:42,719
+of object attached and there's a
+
+3707
+02:14:41,39 --> 02:14:46,238
+relationship to create objections
+
+3708
+02:14:42,719 --> 02:14:48,0
+8082.719 --> 8088
+indeed so so in this case the
+
+3709
+02:14:46,238 --> 02:14:50,158
+relationship is to the email itself so
+
+3710
+02:14:48,0 --> 02:14:52,319
+8088 --> 8092.32
+we know that the email contained
+
+3711
+02:14:50,158 --> 02:14:53,920
+this file so what we can do is we can
+
+3712
+02:14:52,319 --> 02:14:54,479
+just create relationship between the
+
+3713
+02:14:53,920 --> 02:14:56,158
+email
+
+3714
+02:14:54,479 --> 02:14:58,718
+and the file and see that email contain
+
+3715
+02:14:56,158 --> 02:14:58,719
+that file
+
+3716
+02:15:00,719 --> 02:15:04,800
+do you see it it's again the same model
+
+3717
+02:15:02,639 --> 02:15:04,800
+so
+
+3718
+02:15:06,880 --> 02:15:09,840
+contains
+
+3719
+02:15:15,439 --> 02:15:19,839
+there we go so now what we can do is if
+
+3720
+02:15:18,319 --> 02:15:21,39
+you look further in the email we see
+
+3721
+02:15:19,840 --> 02:15:22,480
+that there is a bunch of other stuff
+
+3722
+02:15:21,39 --> 02:15:23,198
+still described so what we can do is we
+
+3723
+02:15:22,479 --> 02:15:27,598
+can just
+
+3724
+02:15:23,198 --> 02:15:30,238
+now for exercise sake just take um
+
+3725
+02:15:27,599 --> 02:15:30,880
+at least a next few lines or the next
+
+3726
+02:15:30,238 --> 02:15:33,198
+paragraph
+
+3727
+02:15:30,880 --> 02:15:35,118
+and drop the entire paragraph into
+
+3728
+02:15:33,198 --> 02:15:37,118
+something called the free text importer
+
+3729
+02:15:35,118 --> 02:15:38,319
+what this will do is it will try to
+
+3730
+02:15:37,118 --> 02:15:40,238
+parse this uh
+
+3731
+02:15:38,319 --> 02:15:41,679
+this text blob and it will try to
+
+3732
+02:15:40,238 --> 02:15:43,678
+extract anything that looks like an
+
+3733
+02:15:41,679 --> 02:15:44,319
+indicator out of that so this is another
+
+3734
+02:15:43,679 --> 02:15:46,78
+method of
+
+3735
+02:15:44,319 --> 02:15:49,39
+of basically entering attribute
+
+3736
+02:15:46,78 --> 02:15:51,679
+synthesis so free text import
+
+3737
+02:15:49,39 --> 02:15:54,319
+we just paste it in there and we just
+
+3738
+02:15:51,679 --> 02:15:54,319
+hit submit
+
+3739
+02:15:54,399 --> 02:15:57,679
+so this will tell us in this case it
+
+3740
+02:15:55,760 --> 02:15:59,280
+didn't extract everything actually so we
+
+3741
+02:15:57,679 --> 02:16:00,158
+need to still go back to it and refined
+
+3742
+02:15:59,279 --> 02:16:01,920
+a bit more
+
+3743
+02:16:00,158 --> 02:16:03,118
+but it extracted some of those things
+
+3744
+02:16:01,920 --> 02:16:05,39
+that were in there already so that's
+
+3745
+02:16:03,118 --> 02:16:07,598
+fine we can just already add those
+
+3746
+02:16:05,39 --> 02:16:07,599
+to the event
+
+3747
+02:16:08,238 --> 02:16:12,479
+so how does it work in in behind the
+
+3748
+02:16:10,238 --> 02:16:13,519
+scenes uh we have a bunch of regex
+
+3749
+02:16:12,479 --> 02:16:15,198
+images
+
+3750
+02:16:13,520 --> 02:16:17,199
+automatically extracting information
+
+3751
+02:16:15,198 --> 02:16:18,719
+from from natural text
+
+3752
+02:16:17,198 --> 02:16:20,559
+it's one way to do it there's another
+
+3753
+02:16:18,719 --> 02:16:21,760
+tool for doing it which is part of the
+
+3754
+02:16:20,560 --> 02:16:24,639
+even report
+
+3755
+02:16:21,760 --> 02:16:26,159
+um but it's usually it's a quick way to
+
+3756
+02:16:24,639 --> 02:16:28,880
+automatically extract information and to
+
+3757
+02:16:26,158 --> 02:16:31,198
+see if it's already known for example
+
+3758
+02:16:28,880 --> 02:16:32,318
+so what we see here already is that evil
+
+3759
+02:16:31,198 --> 02:16:35,119
+provider
+
+3760
+02:16:32,318 --> 02:16:36,79
+was basically according to the email
+
+3761
+02:16:35,120 --> 02:16:38,800
+text
+
+3762
+02:16:36,79 --> 02:16:40,959
+and the place that was uh used to
+
+3763
+02:16:38,799 --> 02:16:43,920
+download the secondary payload from
+
+3764
+02:16:40,959 --> 02:16:44,558
+so we can take evil provider and we also
+
+3765
+02:16:43,920 --> 02:16:46,719
+know that
+
+3766
+02:16:44,558 --> 02:16:47,920
+we got an ipv6 address to it so we're
+
+3767
+02:16:46,718 --> 02:16:51,39
+going to add that to it as well and
+
+3768
+02:16:47,920 --> 02:16:52,879
+convert this into an object again
+
+3769
+02:16:51,40 --> 02:16:54,880
+so we're going to to just select that
+
+3770
+02:16:52,879 --> 02:16:55,438
+one convert to object and the object
+
+3771
+02:16:54,879 --> 02:16:58,159
+that we're
+
+3772
+02:16:55,439 --> 02:17:01,599
+going to convert it to is going to be a
+
+3773
+02:16:58,159 --> 02:17:04,799
+url object
+
+3774
+02:17:01,599 --> 02:17:07,120
+yep all the way down there perfect
+
+3775
+02:17:04,799 --> 02:17:08,558
+let's just do the conversion and then we
+
+3776
+02:17:07,120 --> 02:17:09,920
+edit the object afterwards and we add
+
+3777
+02:17:08,558 --> 02:17:12,318
+the additional information that we have
+
+3778
+02:17:09,920 --> 02:17:12,318
+about it
+
+3779
+02:17:12,638 --> 02:17:18,318
+so we have an ipv6 that we can that it
+
+3780
+02:17:15,840 --> 02:17:18,318
+resolves to
+
+3781
+02:17:24,239 --> 02:17:29,840
+we also have a port so once we're done
+
+3782
+02:17:26,959 --> 02:17:29,839
+with that
+
+3783
+02:17:31,280 --> 02:17:34,639
+happy destination perfect
+
+3784
+02:17:36,159 --> 02:17:43,840
+we can also add the port it was
+
+3785
+02:17:38,799 --> 02:17:43,840
+communicating on port 443
+
+3786
+02:17:46,558 --> 02:17:50,239
+and again everything i'm currently doing
+
+3787
+02:17:48,799 --> 02:17:53,920
+there can be done through
+
+3788
+02:17:50,239 --> 02:17:57,840
+api obviously yeah and and finally we
+
+3789
+02:17:53,920 --> 02:17:57,840
+also have a domain evilprovider.com
+
+3790
+02:18:02,638 --> 02:18:08,79
+now let's deal with with referencing the
+
+3791
+02:18:05,840 --> 02:18:09,40
+this to the other objects later on we
+
+3792
+02:18:08,79 --> 02:18:11,280
+can still
+
+3793
+02:18:09,40 --> 02:18:12,960
+still add the additional information
+
+3794
+02:18:11,280 --> 02:18:15,439
+that we have in there and then we do the
+
+3795
+02:18:12,959 --> 02:18:17,358
+linking afterwards again we we have the
+
+3796
+02:18:15,439 --> 02:18:20,159
+same problem here on this one because
+
+3797
+02:18:17,359 --> 02:18:21,760
+you see that the command has a the part
+
+3798
+02:18:20,159 --> 02:18:23,679
+it has a command so that means we can
+
+3799
+02:18:21,760 --> 02:18:25,359
+just convert it as an object again
+
+3800
+02:18:23,679 --> 02:18:27,679
+yeah and the ip belongs to that one as
+
+3801
+02:18:25,359 --> 02:18:30,719
+well by the way okay great
+
+3802
+02:18:27,679 --> 02:18:31,679
+it's even better yeah exactly just my
+
+3803
+02:18:30,718 --> 02:18:39,839
+screen that is a bit
+
+3804
+02:18:31,679 --> 02:18:39,840
+smaller okay
+
+3805
+02:18:40,318 --> 02:18:43,920
+so in this case it's again a url
+
+3806
+02:18:49,359 --> 02:18:54,719
+and the things that we have this time
+
+3807
+02:18:52,718 --> 02:18:56,239
+the port is actually a high port so
+
+3808
+02:18:54,718 --> 02:18:58,79
+while in the other one we do not
+
+3809
+02:18:56,239 --> 02:18:59,519
+correlate on on the port because port
+
+3810
+02:18:58,79 --> 02:19:01,359
+443 is common
+
+3811
+02:18:59,519 --> 02:19:03,40
+this is one of those ports that we might
+
+3812
+02:19:01,359 --> 02:19:04,639
+want to correlate on already
+
+3813
+02:19:03,40 --> 02:19:07,840
+so we want we don't want to disable
+
+3814
+02:19:04,638 --> 02:19:07,839
+correlation for this one
+
+3815
+02:19:09,840 --> 02:19:13,120
+once for the other one we we should
+
+3816
+02:19:11,679 --> 02:19:15,439
+disable the correlation for the other
+
+3817
+02:19:13,120 --> 02:19:15,439
+part
+
+3818
+02:19:18,840 --> 02:19:25,280
+443
+
+3819
+02:19:21,280 --> 02:19:27,280
+okay now the other thing that we have at
+
+3820
+02:19:25,280 --> 02:19:28,719
+this point is we have a secondary sample
+
+3821
+02:19:27,280 --> 02:19:30,719
+so if you can you have a second one that
+
+3822
+02:19:28,718 --> 02:19:34,959
+you can upload yeah i just just add the
+
+3823
+02:19:30,718 --> 02:19:39,279
+domain so i get it
+
+3824
+02:19:34,959 --> 02:19:41,358
+okay so what do you want
+
+3825
+02:19:39,280 --> 02:19:42,479
+so we still have another file to update
+
+3826
+02:19:41,359 --> 02:19:45,359
+and we have a cv
+
+3827
+02:19:42,478 --> 02:19:48,318
+that was also mentioned in the okay cv
+
+3828
+02:19:45,359 --> 02:19:50,559
+it's an interesting one um
+
+3829
+02:19:48,318 --> 02:19:51,519
+we have we have single attributes for cd
+
+3830
+02:19:50,559 --> 02:19:53,119
+but
+
+3831
+02:19:51,520 --> 02:19:55,680
+sometimes you want to have some more
+
+3832
+02:19:53,120 --> 02:19:56,160
+information so what you could do there
+
+3833
+02:19:55,680 --> 02:19:58,960
+is
+
+3834
+02:19:56,159 --> 02:20:02,719
+to create a simple attribute um so the
+
+3835
+02:19:58,959 --> 02:20:05,438
+cv is much better delivery in this case
+
+3836
+02:20:02,719 --> 02:20:08,79
+we have type which is vulnerability and
+
+3837
+02:20:05,439 --> 02:20:11,200
+usually a venerability is defined by cv
+
+3838
+02:20:08,79 --> 02:20:12,719
+you can you can use other value but
+
+3839
+02:20:11,200 --> 02:20:14,880
+the best practice is the obviously to
+
+3840
+02:20:12,719 --> 02:20:17,119
+use cd
+
+3841
+02:20:14,879 --> 02:20:19,39
+it's very old cv those kind of attackers
+
+3842
+02:20:17,120 --> 02:20:21,120
+are always reusing those kind of old
+
+3843
+02:20:19,40 --> 02:20:22,640
+things but you know it works you know
+
+3844
+02:20:21,120 --> 02:20:25,439
+never people never patch i
+
+3845
+02:20:22,639 --> 02:20:26,799
+know this one is interesting because you
+
+3846
+02:20:25,439 --> 02:20:29,439
+know it was exploited
+
+3847
+02:20:26,799 --> 02:20:31,199
+so i would add the ideas flag because it
+
+3848
+02:20:29,439 --> 02:20:32,159
+may be interesting to look into your
+
+3849
+02:20:31,200 --> 02:20:35,40
+system for
+
+3850
+02:20:32,159 --> 02:20:36,398
+additional ones so in this case what do
+
+3851
+02:20:35,40 --> 02:20:39,439
+we have we have again
+
+3852
+02:20:36,398 --> 02:20:41,358
+a single attribute which is not the nice
+
+3853
+02:20:39,439 --> 02:20:43,520
+thing that you want to have is basically
+
+3854
+02:20:41,359 --> 02:20:44,318
+you want to have as much context as you
+
+3855
+02:20:43,520 --> 02:20:47,600
+want
+
+3856
+02:20:44,318 --> 02:20:48,0
+8444.319 --> 8448
+for such kind of investigation luckily
+
+3857
+02:20:47,600 --> 02:20:51,40
+on
+
+3858
+02:20:48,0 --> 02:20:53,359
+8448 --> 8453.359
+this instance we have one of those
+
+3859
+02:20:51,40 --> 02:20:58,479
+expansion modules
+
+3860
+02:20:53,359 --> 02:21:00,559
+and why the cv advantage is okay
+
+3861
+02:20:58,478 --> 02:21:02,79
+great so and then you have some
+
+3862
+02:21:00,559 --> 02:21:03,840
+additional information in this case we
+
+3863
+02:21:02,79 --> 02:21:06,959
+have some some description
+
+3864
+02:21:03,840 --> 02:21:07,920
+um so what i can do in this in this one
+
+3865
+02:21:06,959 --> 02:21:11,358
+is
+
+3866
+02:21:07,920 --> 02:21:14,639
+so you see that we have either the
+
+3867
+02:21:11,359 --> 02:21:16,318
+overlay uh thing so in these modules uh
+
+3868
+02:21:14,639 --> 02:21:16,959
+someone was asking about extension of
+
+3869
+02:21:16,318 --> 02:21:18,719
+this
+
+3870
+02:21:16,959 --> 02:21:19,759
+is one way you have this overlay things
+
+3871
+02:21:18,719 --> 02:21:20,639
+where you can basically just do
+
+3872
+02:21:19,760 --> 02:21:23,680
+expansions
+
+3873
+02:21:20,639 --> 02:21:25,119
+and see okay contextual information but
+
+3874
+02:21:23,680 --> 02:21:26,960
+sometimes you just want to be
+
+3875
+02:21:25,120 --> 02:21:29,190
+to have a bit more than just contextual
+
+3876
+02:21:26,959 --> 02:21:31,199
+information uh you want to have
+
+3877
+02:21:29,190 --> 02:21:33,920
+[Music]
+
+3878
+02:21:31,200 --> 02:21:36,240
+the uh associated object then so there
+
+3879
+02:21:33,920 --> 02:21:38,159
+you have this this kind of
+
+3880
+02:21:36,239 --> 02:21:40,879
+kind of explosion there and you can add
+
+3881
+02:21:38,159 --> 02:21:42,79
+the enrichment i'll give a try on that
+
+3882
+02:21:40,879 --> 02:21:44,79
+one
+
+3883
+02:21:42,79 --> 02:21:45,920
+okay great so there's something wrong on
+
+3884
+02:21:44,79 --> 02:21:48,478
+this machine that's great
+
+3885
+02:21:45,920 --> 02:21:49,840
+i'll take the other one but this this
+
+3886
+02:21:48,478 --> 02:21:53,199
+it's not an object for that
+
+3887
+02:21:49,840 --> 02:21:55,120
+that's fine we can just like yeah can
+
+3888
+02:21:53,200 --> 02:21:56,399
+summon the attribute in this case
+
+3889
+02:21:55,120 --> 02:21:58,560
+so we have basically the description
+
+3890
+02:21:56,398 --> 02:22:01,599
+then coming from the enrichment
+
+3891
+02:21:58,559 --> 02:22:04,239
+and what we can do is to uh
+
+3892
+02:22:01,600 --> 02:22:05,520
+then make an object called vulnerability
+
+3893
+02:22:04,239 --> 02:22:07,920
+then
+
+3894
+02:22:05,520 --> 02:22:09,359
+id credit in this case is the
+
+3895
+02:22:07,920 --> 02:22:12,398
+descriptions
+
+3896
+02:22:09,359 --> 02:22:14,559
+and make an object of it usually you
+
+3897
+02:22:12,398 --> 02:22:16,639
+should have a full
+
+3898
+02:22:14,559 --> 02:22:19,39
+expansion there but i didn't test it on
+
+3899
+02:22:16,639 --> 02:22:22,559
+the training instance maybe something is
+
+3900
+02:22:19,40 --> 02:22:23,280
+broken on that instance okay so now what
+
+3901
+02:22:22,559 --> 02:22:25,920
+do we have is
+
+3902
+02:22:23,280 --> 02:22:27,840
+it's more contextual information we we
+
+3903
+02:22:25,920 --> 02:22:29,520
+start with a story and there
+
+3904
+02:22:27,840 --> 02:22:31,920
+we see that we have an emails we have a
+
+3905
+02:22:29,520 --> 02:22:34,640
+first url a second one which is a
+
+3906
+02:22:31,920 --> 02:22:36,239
+download and a specific cv so maybe no
+
+3907
+02:22:34,639 --> 02:22:38,79
+we can go back to the uh
+
+3908
+02:22:36,239 --> 02:22:39,280
+we still miss one thing which was a
+
+3909
+02:22:38,79 --> 02:22:42,239
+secondary file that was
+
+3910
+02:22:39,280 --> 02:22:43,40
+downloaded oh okay from the secondary
+
+3911
+02:22:42,239 --> 02:22:46,799
+files yes
+
+3912
+02:22:43,40 --> 02:22:47,280
+yeah so according to story what happens
+
+3913
+02:22:46,799 --> 02:22:50,318
+was
+
+3914
+02:22:47,280 --> 02:22:52,319
+uh the initial sample was uh
+
+3915
+02:22:50,318 --> 02:22:54,239
+when executed was downloading a
+
+3916
+02:22:52,318 --> 02:22:56,559
+secondary
+
+3917
+02:22:54,239 --> 02:22:57,680
+sample and that one was basically then
+
+3918
+02:22:56,559 --> 02:23:00,719
+used to
+
+3919
+02:22:57,680 --> 02:23:01,40
+exfiltrate data from from the system yes
+
+3920
+02:23:00,719 --> 02:23:03,519
+so
+
+3921
+02:23:01,40 --> 02:23:05,200
+this was a new railway download the
+
+3922
+02:23:03,520 --> 02:23:08,479
+interest files okay
+
+3923
+02:23:05,200 --> 02:23:09,600
+then i will add a yeah just another file
+
+3924
+02:23:08,478 --> 02:23:11,599
+and we just
+
+3925
+02:23:09,600 --> 02:23:13,200
+pretend it's the one that we were
+
+3926
+02:23:11,600 --> 02:23:14,239
+supposed to use why is this one it makes
+
+3927
+02:23:13,200 --> 02:23:17,280
+sense it's an emote that's one
+
+3928
+02:23:14,239 --> 02:23:17,280
+downloaded form in your eyes
+
+3929
+02:23:17,439 --> 02:23:20,159
+that makes sense
+
+3930
+02:23:21,359 --> 02:23:24,399
+so now we have all these different
+
+3931
+02:23:22,959 --> 02:23:25,919
+objects in our event and it's time to
+
+3932
+02:23:24,398 --> 02:23:27,439
+build the story out of it as alex has
+
+3933
+02:23:25,920 --> 02:23:33,840
+mentioned so it's time to go back to our
+
+3934
+02:23:27,439 --> 02:23:33,840
+event graph
+
+3935
+02:23:34,879 --> 02:23:38,0
+8614.88 --> 8618
+and basically uh so far the story is
+
+3936
+02:23:37,200 --> 02:23:39,920
+that we got
+
+3937
+02:23:38,0 --> 02:23:42,559
+8618 --> 8622.56
+an email the email was impersonating a
+
+3938
+02:23:39,920 --> 02:23:44,799
+person and we basically got
+
+3939
+02:23:42,559 --> 02:23:45,840
+a primary sample out of the that primary
+
+3940
+02:23:44,799 --> 02:23:50,398
+sample then reaches
+
+3941
+02:23:45,840 --> 02:23:50,398
+out to evilprovider.com
+
+3942
+02:23:50,559 --> 02:23:55,600
+to download a secondary sample so we
+
+3943
+02:23:53,680 --> 02:23:59,120
+have a relationship
+
+3944
+02:23:55,600 --> 02:24:02,239
+between the file
+
+3945
+02:23:59,120 --> 02:24:02,240
+which downloads from
+
+3946
+02:24:02,318 --> 02:24:09,119
+downloads from yeah perfect
+
+3947
+02:24:06,959 --> 02:24:10,799
+from evil provider and then evil
+
+3948
+02:24:09,120 --> 02:24:15,840
+provider downloads
+
+3949
+02:24:10,799 --> 02:24:15,840
+the secondary sample
+
+3950
+02:24:19,200 --> 02:24:29,840
+which is in this case index dot html one
+
+3951
+02:24:33,359 --> 02:24:43,840
+and this one then exfiltrates to the
+
+3952
+02:24:36,398 --> 02:24:43,840
+another evil provider url
+
+3953
+02:24:52,239 --> 02:24:55,600
+now there's one thing we missed in the
+
+3954
+02:24:53,520 --> 02:24:57,40
+story here is that the first one try so
+
+3955
+02:24:55,600 --> 02:25:00,159
+in this case trilogy
+
+3956
+02:24:57,40 --> 02:25:03,40
+was actually abusing the cve that uh
+
+3957
+02:25:00,159 --> 02:25:04,398
+that alex has already expanded so we
+
+3958
+02:25:03,40 --> 02:25:08,560
+have an abuser's
+
+3959
+02:25:04,398 --> 02:25:08,559
+relationship from trilogothexa to
+
+3960
+02:25:08,840 --> 02:25:11,840
+vulnerability
+
+3961
+02:25:13,680 --> 02:25:17,359
+so and once we're done with this we
+
+3962
+02:25:15,760 --> 02:25:19,439
+already see the entire store in this car
+
+3963
+02:25:17,359 --> 02:25:20,800
+so even if you if you have no idea about
+
+3964
+02:25:19,439 --> 02:25:22,800
+what happened in the report and you
+
+3965
+02:25:20,799 --> 02:25:24,318
+don't read the original report
+
+3966
+02:25:22,799 --> 02:25:26,478
+by just looking at this graph you can
+
+3967
+02:25:24,318 --> 02:25:29,519
+clearly read it out
+
+3968
+02:25:26,478 --> 02:25:31,519
+in in in simple sentences we see email
+
+3969
+02:25:29,520 --> 02:25:34,960
+in person later first and john
+
+3970
+02:25:31,520 --> 02:25:36,159
+email contains trilogy exploits
+
+3971
+02:25:34,959 --> 02:25:39,159
+vulnerability
+
+3972
+02:25:36,159 --> 02:25:40,318
+downloads from evoprovider.com
+
+3973
+02:25:39,159 --> 02:25:43,680
+index.html1
+
+3974
+02:25:40,318 --> 02:25:45,760
+which exfiltrates to a url so it's a
+
+3975
+02:25:43,680 --> 02:25:46,79
+very simple story to comprehend without
+
+3976
+02:25:45,760 --> 02:25:48,239
+us
+
+3977
+02:25:46,79 --> 02:25:50,0
+8746.08 --> 8750
+knowing the original data information
+
+3978
+02:25:48,239 --> 02:25:50,318
+and without us having even having to
+
+3979
+02:25:50,0 --> 02:25:52,0
+8750 --> 8752
+look
+
+3980
+02:25:50,318 --> 02:25:53,359
+at the individual indicators further
+
+3981
+02:25:52,0 --> 02:25:55,760
+8752 --> 8755.76
+below
+
+3982
+02:25:53,359 --> 02:25:56,800
+so this is when we're talking about
+
+3983
+02:25:55,760 --> 02:25:59,40
+information sharing
+
+3984
+02:25:56,799 --> 02:26:00,478
+we're basically sharing on two layers
+
+3985
+02:25:59,40 --> 02:26:02,640
+one of the layers is sharing with
+
+3986
+02:26:00,478 --> 02:26:04,79
+machines so informing an ids about
+
+3987
+02:26:02,639 --> 02:26:05,599
+things to alert on
+
+3988
+02:26:04,79 --> 02:26:07,280
+and at the same time we're sharing with
+
+3989
+02:26:05,600 --> 02:26:09,40
+analysts that want to really understand
+
+3990
+02:26:07,280 --> 02:26:09,600
+what the introductory was doing in this
+
+3991
+02:26:09,40 --> 02:26:11,760
+case
+
+3992
+02:26:09,600 --> 02:26:13,120
+and what happened during the incident
+
+3993
+02:26:11,760 --> 02:26:15,600
+however at this stage
+
+3994
+02:26:13,120 --> 02:26:17,520
+we have described our event but we're
+
+3995
+02:26:15,600 --> 02:26:20,479
+still missing something at this point
+
+3996
+02:26:17,520 --> 02:26:21,760
+we still haven't actually contextualized
+
+3997
+02:26:20,478 --> 02:26:23,39
+the information with everything else
+
+3998
+02:26:21,760 --> 02:26:26,159
+that we know about it
+
+3999
+02:26:23,40 --> 02:26:27,40
+so we have we have vocabularies at our
+
+4000
+02:26:26,159 --> 02:26:28,879
+disposal
+
+4001
+02:26:27,40 --> 02:26:30,399
+we have at the attack matrix at our
+
+4002
+02:26:28,879 --> 02:26:31,679
+disposal so let's
+
+4003
+02:26:30,398 --> 02:26:33,760
+start going through the individual
+
+4004
+02:26:31,680 --> 02:26:34,559
+attributes and let's start to attach
+
+4005
+02:26:33,760 --> 02:26:37,520
+those different
+
+4006
+02:26:34,559 --> 02:26:38,79
+labels to the data so first of all if we
+
+4007
+02:26:37,520 --> 02:26:41,120
+look at
+
+4008
+02:26:38,79 --> 02:26:42,318
+uh perhaps which one which one should we
+
+4009
+02:26:41,120 --> 02:26:44,79
+start with
+
+4010
+02:26:42,318 --> 02:26:45,760
+let's not do everything let's look at
+
+4011
+02:26:44,79 --> 02:26:47,520
+the original email for example
+
+4012
+02:26:45,760 --> 02:26:49,120
+we know that the original email deals
+
+4013
+02:26:47,520 --> 02:26:51,120
+with fishing now
+
+4014
+02:26:49,120 --> 02:26:52,720
+attack has a pattern that describes
+
+4015
+02:26:51,120 --> 02:26:55,760
+fishing so we can just attach
+
+4016
+02:26:52,719 --> 02:26:59,279
+the galaxy cluster of attack to
+
+4017
+02:26:55,760 --> 02:27:02,960
+and to the attributes in there so
+
+4018
+02:26:59,280 --> 02:27:04,800
+we use cluster yeah and we can just use
+
+4019
+02:27:02,959 --> 02:27:07,759
+the text
+
+4020
+02:27:04,799 --> 02:27:08,318
+magic perfect and we can click on attack
+
+4021
+02:27:07,760 --> 02:27:11,200
+pattern
+
+4022
+02:27:08,318 --> 02:27:12,79
+then we get the attack matrix and here
+
+4023
+02:27:11,200 --> 02:27:16,290
+we can select
+
+4024
+02:27:12,79 --> 02:27:19,120
+uh phishing it should be in
+
+4025
+02:27:16,290 --> 02:27:20,880
+[Music]
+
+4026
+02:27:19,120 --> 02:27:23,359
+you see yeah there it is perfect so we
+
+4027
+02:27:20,879 --> 02:27:23,358
+attach it
+
+4028
+02:27:23,840 --> 02:27:27,359
+we refresh and there we see it is now
+
+4029
+02:27:26,318 --> 02:27:30,0
+8846.319 --> 8850
+attached to the
+
+4030
+02:27:27,359 --> 02:27:31,680
+attribute and if we if we generate a
+
+4031
+02:27:30,0 --> 02:27:32,879
+8850 --> 8852.88
+heat pack now out of the events if we
+
+4032
+02:27:31,680 --> 02:27:35,680
+scroll up
+
+4033
+02:27:32,879 --> 02:27:37,39
+we have an attack matrix view next to
+
+4034
+02:27:35,680 --> 02:27:39,520
+the event graph
+
+4035
+02:27:37,40 --> 02:27:40,399
+if we click on that one now we now see
+
+4036
+02:27:39,520 --> 02:27:43,200
+that
+
+4037
+02:27:40,398 --> 02:27:44,0
+8860.399 --> 8864
+as a first overview already we know
+
+4038
+02:27:43,200 --> 02:27:45,520
+without looking
+
+4039
+02:27:44,0 --> 02:27:47,359
+8864 --> 8867.359
+at any of the details we see that we're
+
+4040
+02:27:45,520 --> 02:27:48,800
+dealing with positioning here so this is
+
+4041
+02:27:47,359 --> 02:27:49,600
+one of the attack patterns that we've
+
+4042
+02:27:48,799 --> 02:27:50,879
+described
+
+4043
+02:27:49,600 --> 02:27:52,399
+let's see what other attack patterns
+
+4044
+02:27:50,879 --> 02:27:53,920
+from attack we can describe you also see
+
+4045
+02:27:52,398 --> 02:27:55,599
+that there is automated
+
+4046
+02:27:53,920 --> 02:27:57,520
+exfiltration happening so if we go to
+
+4047
+02:27:55,600 --> 02:28:01,840
+the secondary url
+
+4048
+02:27:57,520 --> 02:28:01,840
+so another evilprovider.com
+
+4049
+02:28:03,280 --> 02:28:06,960
+we can attach the pattern there as well
+
+4050
+02:28:05,520 --> 02:28:08,560
+now we can choose to do
+
+4051
+02:28:06,959 --> 02:28:10,159
+a single attribute what we're doing or
+
+4052
+02:28:08,559 --> 02:28:11,760
+we can just select all four and attach
+
+4053
+02:28:10,159 --> 02:28:12,0
+8890.16 --> 8892
+the cluster tool for let's just do one
+
+4054
+02:28:11,760 --> 02:28:15,120
+for
+
+4055
+02:28:12,0 --> 02:28:19,760
+8892 --> 8899.76
+now it's it's it's enough
+
+4056
+02:28:15,120 --> 02:28:19,760
+uh watch out it's uh yeah perfect
+
+4057
+02:28:21,40 --> 02:28:24,399
+and just pick automated exfiltration
+
+4058
+02:28:23,600 --> 02:28:27,840
+it's the
+
+4059
+02:28:24,398 --> 02:28:27,840
+first one on the yeah
+
+4060
+02:28:30,79 --> 02:28:33,120
+okay so now we've attached some attack
+
+4061
+02:28:32,0 --> 02:28:35,280
+8912 --> 8915.28
+patterns uh
+
+4062
+02:28:33,120 --> 02:28:36,720
+we we could attach it to the sample as
+
+4063
+02:28:35,280 --> 02:28:38,479
+well what the sample is doing but we're
+
+4064
+02:28:36,719 --> 02:28:40,478
+not going to go through
+
+4065
+02:28:38,478 --> 02:28:42,239
+all that effort let's look at some type
+
+4066
+02:28:40,478 --> 02:28:45,679
+of contextualization
+
+4067
+02:28:42,239 --> 02:28:47,119
+for example maybe this
+
+4068
+02:28:45,680 --> 02:28:49,200
+then it's a matter of test again
+
+4069
+02:28:47,120 --> 02:28:50,560
+regarding the at which level you want to
+
+4070
+02:28:49,200 --> 02:28:53,840
+attach
+
+4071
+02:28:50,559 --> 02:28:54,959
+the galaxy there is the topic is a
+
+4072
+02:28:53,840 --> 02:28:57,439
+matter of fishing
+
+4073
+02:28:54,959 --> 02:29:00,398
+at a global level usually we can add a
+
+4074
+02:28:57,439 --> 02:29:04,239
+galaxy there and then for example
+
+4075
+02:29:00,398 --> 02:29:07,519
+add my tray attack directly there
+
+4076
+02:29:04,239 --> 02:29:09,840
+and select the pattern fishing then
+
+4077
+02:29:07,520 --> 02:29:11,600
+the techniques there directly so you
+
+4078
+02:29:09,840 --> 02:29:13,760
+have different options
+
+4079
+02:29:11,600 --> 02:29:15,760
+usually we recommend to make it as
+
+4080
+02:29:13,760 --> 02:29:17,200
+attribute level
+
+4081
+02:29:15,760 --> 02:29:18,880
+but in some case you don't even know
+
+4082
+02:29:17,200 --> 02:29:22,79
+which attribute level it applies
+
+4083
+02:29:18,879 --> 02:29:24,318
+then you select the even level exactly
+
+4084
+02:29:22,79 --> 02:29:25,840
+so so that's indeed a good point if you
+
+4085
+02:29:24,318 --> 02:29:26,959
+know that the entire chain of what
+
+4086
+02:29:25,840 --> 02:29:29,680
+you're describing
+
+4087
+02:29:26,959 --> 02:29:32,0
+8966.96 --> 8972
+referring to the single uh
+
+4088
+02:29:29,680 --> 02:29:34,559
+contextualization beta label be it a
+
+4089
+02:29:32,0 --> 02:29:36,398
+8972 --> 8976.399
+galaxy cluster then indeed what we
+
+4090
+02:29:34,559 --> 02:29:38,719
+assume is anything that you label on the
+
+4091
+02:29:36,398 --> 02:29:41,439
+event level is inherited by all
+
+4092
+02:29:38,719 --> 02:29:42,398
+uh data contained in unless explicitly
+
+4093
+02:29:41,439 --> 02:29:45,760
+overwritten by
+
+4094
+02:29:42,398 --> 02:29:48,478
+the opposite tag basically so
+
+4095
+02:29:45,760 --> 02:29:49,439
+so indeed that's the case uh in this
+
+4096
+02:29:48,478 --> 02:29:51,39
+case
+
+4097
+02:29:49,439 --> 02:29:52,720
+we're kind of in a weird situation
+
+4098
+02:29:51,40 --> 02:29:54,560
+because we're describing the full chain
+
+4099
+02:29:52,719 --> 02:29:56,719
+of the attack which includes initial
+
+4100
+02:29:54,559 --> 02:29:58,559
+phishing attempt but also includes the
+
+4101
+02:29:56,719 --> 02:29:59,358
+secondary payload and the exfiltration
+
+4102
+02:29:58,559 --> 02:30:00,959
+and so on
+
+4103
+02:29:59,359 --> 02:30:02,479
+and if we if you do this on the
+
+4104
+02:30:00,959 --> 02:30:03,39
+attribute level i suppose the event
+
+4105
+02:30:02,478 --> 02:30:05,519
+level
+
+4106
+02:30:03,40 --> 02:30:06,560
+then you're really really only
+
+4107
+02:30:05,520 --> 02:30:08,479
+describing
+
+4108
+02:30:06,559 --> 02:30:10,398
+which part deals with the fishing which
+
+4109
+02:30:08,478 --> 02:30:11,39
+part deals with the actual exfiltration
+
+4110
+02:30:10,398 --> 02:30:12,799
+and so on
+
+4111
+02:30:11,40 --> 02:30:14,640
+so this is really up to you what we
+
+4112
+02:30:12,799 --> 02:30:16,398
+generally recommend is
+
+4113
+02:30:14,639 --> 02:30:18,398
+don't just do it on the event level so
+
+4114
+02:30:16,398 --> 02:30:19,439
+if you're describing more concepts in a
+
+4115
+02:30:18,398 --> 02:30:20,719
+single event
+
+4116
+02:30:19,439 --> 02:30:22,559
+make sure that you contextualize
+
+4117
+02:30:20,719 --> 02:30:23,920
+individual parts of it
+
+4118
+02:30:22,559 --> 02:30:25,840
+because one of one of the things that we
+
+4119
+02:30:23,920 --> 02:30:27,359
+use these labels for as well is searches
+
+4120
+02:30:25,840 --> 02:30:28,318
+so if i were to search for all
+
+4121
+02:30:27,359 --> 02:30:30,800
+indicators
+
+4122
+02:30:28,318 --> 02:30:32,159
+that relate to phishing i might not want
+
+4123
+02:30:30,799 --> 02:30:35,920
+to get the secondary
+
+4124
+02:30:32,159 --> 02:30:37,760
+payloads effects uh included in that
+
+4125
+02:30:35,920 --> 02:30:39,359
+response because that was just the
+
+4126
+02:30:37,760 --> 02:30:41,200
+initial vector of getting into the
+
+4127
+02:30:39,359 --> 02:30:42,880
+network of the victim
+
+4128
+02:30:41,200 --> 02:30:44,720
+whatever happens afterwards is not
+
+4129
+02:30:42,879 --> 02:30:46,959
+directly related to the phishing
+
+4130
+02:30:44,719 --> 02:30:48,478
+so keep that in mind as well something
+
+4131
+02:30:46,959 --> 02:30:50,559
+else
+
+4132
+02:30:48,478 --> 02:30:52,799
+yeah so some just just something that
+
+4133
+02:30:50,559 --> 02:30:54,639
+you have to keep in mind too it's about
+
+4134
+02:30:52,799 --> 02:30:56,79
+which classification to choose or which
+
+4135
+02:30:54,639 --> 02:30:56,799
+contractualization source you have to
+
+4136
+02:30:56,79 --> 02:30:59,600
+want to
+
+4137
+02:30:56,799 --> 02:31:00,79
+to use um on this instance we have
+
+4138
+02:30:59,600 --> 02:31:02,800
+already
+
+4139
+02:31:00,79 --> 02:31:04,639
+a lot of things enabled and if for
+
+4140
+02:31:02,799 --> 02:31:06,79
+example you go for taxonomy
+
+4141
+02:31:04,639 --> 02:31:08,478
+you have a lot of taxonomy that is
+
+4142
+02:31:06,79 --> 02:31:10,719
+describing fishing
+
+4143
+02:31:08,478 --> 02:31:11,760
+for for example you have even a complete
+
+4144
+02:31:10,719 --> 02:31:14,959
+taxonomy
+
+4145
+02:31:11,760 --> 02:31:15,680
+about the kind of fishing you have and
+
+4146
+02:31:14,959 --> 02:31:18,639
+so on
+
+4147
+02:31:15,680 --> 02:31:21,280
+so when you install your miss pinstance
+
+4148
+02:31:18,639 --> 02:31:23,358
+and you start to make it operational
+
+4149
+02:31:21,280 --> 02:31:24,800
+you really have to decide what kind of
+
+4150
+02:31:23,359 --> 02:31:26,720
+taxonomy you want to use
+
+4151
+02:31:24,799 --> 02:31:29,920
+in this case we have already a lot of
+
+4152
+02:31:26,719 --> 02:31:32,478
+things are available by default
+
+4153
+02:31:29,920 --> 02:31:35,200
+so the fishing taxonomy itself is a
+
+4154
+02:31:32,478 --> 02:31:37,358
+complete one coming from a finger
+
+4155
+02:31:35,200 --> 02:31:39,840
+towards academic paper where we have all
+
+4156
+02:31:37,359 --> 02:31:41,600
+the techniques that are used so
+
+4157
+02:31:39,840 --> 02:31:44,239
+for example you can say that this one is
+
+4158
+02:31:41,600 --> 02:31:44,239
+coming from a
+
+4159
+02:31:44,559 --> 02:31:51,439
+spearfishing which was described there
+
+4160
+02:31:48,318 --> 02:31:54,0
+9108.319 --> 9114
+and you have the different techniques
+
+4161
+02:31:51,439 --> 02:31:55,520
+so in this case it's email spoofing and
+
+4162
+02:31:54,0 --> 02:31:57,760
+9114 --> 9117.76
+you can go deeper there
+
+4163
+02:31:55,520 --> 02:31:58,720
+into the description of what is exactly
+
+4164
+02:31:57,760 --> 02:32:01,840
+the decision
+
+4165
+02:31:58,719 --> 02:32:04,0
+9118.72 --> 9124
+and you can mix match both i mean under
+
+4166
+02:32:01,840 --> 02:32:06,478
+selectively attack
+
+4167
+02:32:04,0 --> 02:32:07,200
+9124 --> 9127.2
+fishing techniques at specific indicator
+
+4168
+02:32:06,478 --> 02:32:09,438
+level
+
+4169
+02:32:07,200 --> 02:32:10,560
+maybe another analyst would want to
+
+4170
+02:32:09,439 --> 02:32:12,239
+classify it
+
+4171
+02:32:10,559 --> 02:32:14,559
+and and maybe the objectives might be
+
+4172
+02:32:12,239 --> 02:32:16,719
+different maybe on one for example
+
+4173
+02:32:14,559 --> 02:32:18,719
+it's more specific for tools but if you
+
+4174
+02:32:16,719 --> 02:32:20,639
+want to run out statistics
+
+4175
+02:32:18,719 --> 02:32:22,0
+9138.72 --> 9142
+at the end of i don't know quite early
+
+4176
+02:32:20,639 --> 02:32:23,840
+meetings and say okay
+
+4177
+02:32:22,0 --> 02:32:25,600
+9142 --> 9145.6
+how many spearfishing that you receive
+
+4178
+02:32:23,840 --> 02:32:27,200
+or many emails proofing
+
+4179
+02:32:25,600 --> 02:32:29,840
+for example if you can control better
+
+4180
+02:32:27,200 --> 02:32:30,720
+emails proofing uh the spf record and so
+
+4181
+02:32:29,840 --> 02:32:32,960
+on you can
+
+4182
+02:32:30,719 --> 02:32:34,719
+just look at the current uh technique
+
+4183
+02:32:32,959 --> 02:32:35,599
+that are used by by the attacker so you
+
+4184
+02:32:34,719 --> 02:32:38,239
+see that
+
+4185
+02:32:35,600 --> 02:32:40,79
+those kind of it's full of taxonomies
+
+4186
+02:32:38,239 --> 02:32:42,799
+that are can be used
+
+4187
+02:32:40,79 --> 02:32:44,559
+and obviously we usually recommend to
+
+4188
+02:32:42,799 --> 02:32:46,639
+not enable everything but just
+
+4189
+02:32:44,559 --> 02:32:47,680
+pick what you really want and some are
+
+4190
+02:32:46,639 --> 02:32:50,79
+very generic
+
+4191
+02:32:47,680 --> 02:32:51,40
+some are more advanced but that's maybe
+
+4192
+02:32:50,79 --> 02:32:54,559
+something that you
+
+4193
+02:32:51,40 --> 02:32:56,319
+we dig into more afterwards but
+
+4194
+02:32:54,559 --> 02:32:57,840
+just be careful of which kind of
+
+4195
+02:32:56,318 --> 02:32:58,799
+taxonomy you want to use because it will
+
+4196
+02:32:57,840 --> 02:33:01,280
+be the language
+
+4197
+02:32:58,799 --> 02:33:02,478
+that you use with the community and your
+
+4198
+02:33:01,280 --> 02:33:07,840
+partners
+
+4199
+02:33:02,478 --> 02:33:07,840
+for sharing this information
+
+4200
+02:33:09,200 --> 02:33:12,640
+maybe something interesting to look into
+
+4201
+02:33:10,879 --> 02:33:14,478
+the email and that's linked to
+
+4202
+02:33:12,639 --> 02:33:16,0
+9192.64 --> 9196
+classifications but there's this comment
+
+4203
+02:33:14,478 --> 02:33:17,840
+there please
+
+4204
+02:33:16,0 --> 02:33:19,520
+9196 --> 9199.52
+please be mindful that this is an
+
+4205
+02:33:17,840 --> 02:33:22,0
+9197.84 --> 9202
+ongoing investigation and we would like
+
+4206
+02:33:19,520 --> 02:33:23,920
+to avoid
+
+4207
+02:33:22,0 --> 02:33:25,439
+9202 --> 9205.439
+informing the attacker or the detection
+
+4208
+02:33:23,920 --> 02:33:28,478
+and can we ask you to
+
+4209
+02:33:25,439 --> 02:33:32,318
+to only use the content information
+
+4210
+02:33:28,478 --> 02:33:34,0
+9208.479 --> 9214
+to to protect your constituents so
+
+4211
+02:33:32,318 --> 02:33:35,519
+this is kind of that you are language
+
+4212
+02:33:34,0 --> 02:33:37,600
+9214 --> 9217.6
+describing to you what kind of
+
+4213
+02:33:35,520 --> 02:33:40,640
+classification it is
+
+4214
+02:33:37,600 --> 02:33:44,479
+um and so no
+
+4215
+02:33:40,639 --> 02:33:46,799
+which one should we use so um if we are
+
+4216
+02:33:44,478 --> 02:33:48,639
+first members if we are using the first
+
+4217
+02:33:46,799 --> 02:33:50,159
+community obviously the classification
+
+4218
+02:33:48,639 --> 02:33:52,398
+that we will use
+
+4219
+02:33:50,159 --> 02:33:53,600
+is not the nato one or the ministry of
+
+4220
+02:33:52,398 --> 02:33:57,920
+defense in whatever
+
+4221
+02:33:53,600 --> 02:34:01,840
+country it's really tlp so then again
+
+4222
+02:33:57,920 --> 02:34:05,920
+based on that we will look into
+
+4223
+02:34:01,840 --> 02:34:09,200
+different taxonomy that we have
+
+4224
+02:34:05,920 --> 02:34:12,719
+we can look for for tlp
+
+4225
+02:34:09,200 --> 02:34:15,280
+and i should not do that like that
+
+4226
+02:34:12,719 --> 02:34:17,39
+i go for the tlp library and then i have
+
+4227
+02:34:15,280 --> 02:34:21,120
+the
+
+4228
+02:34:17,40 --> 02:34:22,240
+specific taxonomy tlp and then you have
+
+4229
+02:34:21,120 --> 02:34:24,560
+the different one
+
+4230
+02:34:22,239 --> 02:34:27,280
+in this case they say you have to share
+
+4231
+02:34:24,559 --> 02:34:29,840
+it with your confusion only so
+
+4232
+02:34:27,280 --> 02:34:30,800
+tlp amber seems to be the most
+
+4233
+02:34:29,840 --> 02:34:33,280
+appropriate
+
+4234
+02:34:30,799 --> 02:34:34,879
+one we say that the lpm bill information
+
+4235
+02:34:33,280 --> 02:34:36,399
+is given to organization
+
+4236
+02:34:34,879 --> 02:34:38,0
+9274.88 --> 9278
+sharing limited within organization to
+
+4237
+02:34:36,398 --> 02:34:40,639
+basically act upon
+
+4238
+02:34:38,0 --> 02:34:41,439
+9278 --> 9281.439
+if we have the extended classifications
+
+4239
+02:34:40,639 --> 02:34:44,478
+from first
+
+4240
+02:34:41,439 --> 02:34:47,200
+it includes the constituent
+
+4241
+02:34:44,478 --> 02:34:48,559
+too so i will just use a tmp but i
+
+4242
+02:34:47,200 --> 02:34:50,159
+mentioned something else that is
+
+4243
+02:34:48,559 --> 02:34:52,959
+interesting
+
+4244
+02:34:50,159 --> 02:34:53,600
+in the email they mentioned that this is
+
+4245
+02:34:52,959 --> 02:34:57,199
+an ongoing
+
+4246
+02:34:53,600 --> 02:35:00,479
+association to avoid
+
+4247
+02:34:57,200 --> 02:35:02,479
+informing the attacker in this case
+
+4248
+02:35:00,478 --> 02:35:03,760
+or would you inform the attacker but if
+
+4249
+02:35:02,478 --> 02:35:06,79
+you do actions
+
+4250
+02:35:03,760 --> 02:35:08,79
+on specific indicators and attributes
+
+4251
+02:35:06,79 --> 02:35:10,239
+you might want to restrict that
+
+4252
+02:35:08,79 --> 02:35:13,200
+so there is a another classification i
+
+4253
+02:35:10,239 --> 02:35:16,398
+don't know if this one is enabled
+
+4254
+02:35:13,200 --> 02:35:19,840
+it's called pap which is exactly that
+
+4255
+02:35:16,398 --> 02:35:22,559
+it's similar to tlp but describing
+
+4256
+02:35:19,840 --> 02:35:24,159
+what you can do with this information if
+
+4257
+02:35:22,559 --> 02:35:26,799
+we don't want to
+
+4258
+02:35:24,159 --> 02:35:27,439
+at least notify the attacker that we are
+
+4259
+02:35:26,799 --> 02:35:29,679
+doing some
+
+4260
+02:35:27,439 --> 02:35:31,40
+further investigations maybe we want to
+
+4261
+02:35:29,680 --> 02:35:34,0
+9329.68 --> 9334
+restrict that
+
+4262
+02:35:31,40 --> 02:35:35,840
+and the prp is really telling you what
+
+4263
+02:35:34,0 --> 02:35:37,200
+9334 --> 9337.2
+are the permissive action that you can
+
+4264
+02:35:35,840 --> 02:35:40,239
+do
+
+4265
+02:35:37,200 --> 02:35:42,479
+in our case for example
+
+4266
+02:35:40,239 --> 02:35:43,520
+non-detectable actions only and that's
+
+4267
+02:35:42,478 --> 02:35:46,398
+really what he wants
+
+4268
+02:35:43,520 --> 02:35:48,239
+because the supporters say okay we have
+
+4269
+02:35:46,398 --> 02:35:49,519
+an ongoing investigation so you don't
+
+4270
+02:35:48,239 --> 02:35:51,600
+want to be here
+
+4271
+02:35:49,520 --> 02:35:53,120
+um other parties are informed so in this
+
+4272
+02:35:51,600 --> 02:35:56,800
+case i will use
+
+4273
+02:35:53,120 --> 02:35:58,800
+red and again this is used at even level
+
+4274
+02:35:56,799 --> 02:36:00,478
+and that's something quite important
+
+4275
+02:35:58,799 --> 02:36:02,719
+because myth will take care of that
+
+4276
+02:36:00,478 --> 02:36:04,639
+um you don't need to set pp rate on
+
+4277
+02:36:02,719 --> 02:36:07,920
+every single attribute
+
+4278
+02:36:04,639 --> 02:36:09,279
+behind it's really at even level so it's
+
+4279
+02:36:07,920 --> 02:36:12,239
+automatically
+
+4280
+02:36:09,280 --> 02:36:14,0
+9369.28 --> 9374
+irritating on all attributes we don't
+
+4281
+02:36:12,239 --> 02:36:16,0
+9372.24 --> 9376
+show it on the interface
+
+4282
+02:36:14,0 --> 02:36:18,239
+9374 --> 9378.24
+because it will be two clamps to you
+
+4283
+02:36:16,0 --> 02:36:21,600
+9376 --> 9381.6
+know overload it with information
+
+4284
+02:36:18,239 --> 02:36:23,280
+but we do it in a way that's on the api
+
+4285
+02:36:21,600 --> 02:36:26,0
+9381.6 --> 9386
+level if you do section of search for
+
+4286
+02:36:23,280 --> 02:36:28,319
+example on even level or attribute level
+
+4287
+02:36:26,0 --> 02:36:30,318
+9386 --> 9390.319
+pip red will be included there if you
+
+4288
+02:36:28,318 --> 02:36:32,318
+have an attribute
+
+4289
+02:36:30,318 --> 02:36:34,799
+containing some information
+
+4290
+02:36:32,318 --> 02:36:38,559
+automatically tags like papers will be
+
+4291
+02:36:34,799 --> 02:36:40,0
+9394.8 --> 9400
+then included into the information so
+
+4292
+02:36:38,559 --> 02:36:41,840
+that's something to keep in mind when we
+
+4293
+02:36:40,0 --> 02:36:43,359
+9400 --> 9403.359
+have information from third party
+
+4294
+02:36:41,840 --> 02:36:45,439
+is to to wonder okay what is a
+
+4295
+02:36:43,359 --> 02:36:46,559
+classification scheme so sometimes they
+
+4296
+02:36:45,439 --> 02:36:48,398
+don't say
+
+4297
+02:36:46,559 --> 02:36:50,478
+a specific classification to use that
+
+4298
+02:36:48,398 --> 02:36:53,439
+you just use natural language or
+
+4299
+02:36:50,478 --> 02:36:56,159
+just a normal sentence to describe all
+
+4300
+02:36:53,439 --> 02:36:57,760
+the information should be shared
+
+4301
+02:36:56,159 --> 02:36:59,200
+so the interesting thing here is that
+
+4302
+02:36:57,760 --> 02:37:00,800
+what we've seen now is we've
+
+4303
+02:36:59,200 --> 02:37:02,399
+contextualized information in many
+
+4304
+02:37:00,799 --> 02:37:05,519
+different aspects and this is just
+
+4305
+02:37:02,398 --> 02:37:08,159
+scraping the uh
+
+4306
+02:37:05,520 --> 02:37:09,760
+the top layer basically we could go much
+
+4307
+02:37:08,159 --> 02:37:11,680
+much further with contextualization
+
+4308
+02:37:09,760 --> 02:37:13,359
+imagine for example describing
+
+4309
+02:37:11,680 --> 02:37:15,120
+how this information is relevant to
+
+4310
+02:37:13,359 --> 02:37:16,239
+whether it's used what sort of
+
+4311
+02:37:15,120 --> 02:37:17,920
+mechanisms they should
+
+4312
+02:37:16,239 --> 02:37:19,760
+have in place to be able to block this
+
+4313
+02:37:17,920 --> 02:37:20,879
+information how can you make this useful
+
+4314
+02:37:19,760 --> 02:37:22,159
+think of different maturity
+
+4315
+02:37:20,879 --> 02:37:23,679
+organizations as well when you're
+
+4316
+02:37:22,159 --> 02:37:25,280
+sharing information
+
+4317
+02:37:23,680 --> 02:37:26,639
+you could also describe information
+
+4318
+02:37:25,280 --> 02:37:27,840
+about who's behind it what the
+
+4319
+02:37:26,639 --> 02:37:29,920
+motivations are
+
+4320
+02:37:27,840 --> 02:37:31,760
+so we did not describe the threat actor
+
+4321
+02:37:29,920 --> 02:37:33,359
+because we we haven't done any analysis
+
+4322
+02:37:31,760 --> 02:37:34,318
+yet this is the initial information we
+
+4323
+02:37:33,359 --> 02:37:36,640
+got from
+
+4324
+02:37:34,318 --> 02:37:38,959
+a cser that just reported an incident to
+
+4325
+02:37:36,639 --> 02:37:41,39
+us but we could go further and we
+
+4326
+02:37:38,959 --> 02:37:42,799
+if we did our analysis we would find
+
+4327
+02:37:41,40 --> 02:37:44,960
+who's behind this we could go for it
+
+4328
+02:37:42,799 --> 02:37:47,119
+for uh for information with threat actor
+
+4329
+02:37:44,959 --> 02:37:49,279
+we could look at target sectors
+
+4330
+02:37:47,120 --> 02:37:51,600
+we could look at a lot of different
+
+4331
+02:37:49,280 --> 02:37:52,960
+information in regards to
+
+4332
+02:37:51,600 --> 02:37:55,439
+to further contextualizing the
+
+4333
+02:37:52,959 --> 02:37:55,438
+information
+
+4334
+02:37:58,239 --> 02:38:01,439
+so in this case we could also for
+
+4335
+02:37:59,600 --> 02:38:02,479
+example say that's in the truth where
+
+4336
+02:38:01,439 --> 02:38:03,680
+because we we know that this is
+
+4337
+02:38:02,478 --> 02:38:05,119
+something that was targeting an
+
+4338
+02:38:03,680 --> 02:38:07,760
+organization luxembourg
+
+4339
+02:38:05,120 --> 02:38:08,720
+we know it was there is also a sector uh
+
+4340
+02:38:07,760 --> 02:38:11,359
+taxonomy
+
+4341
+02:38:08,719 --> 02:38:12,639
+that you can use so that's not a galaxy
+
+4342
+02:38:11,359 --> 02:38:14,720
+but the taxonomy
+
+4343
+02:38:12,639 --> 02:38:16,398
+so we can also add uh for example
+
+4344
+02:38:14,719 --> 02:38:17,438
+information about the financial sector
+
+4345
+02:38:16,398 --> 02:38:20,79
+we know the ceo
+
+4346
+02:38:17,439 --> 02:38:21,600
+is a ceo financial sector organization
+
+4347
+02:38:20,79 --> 02:38:23,760
+so we could also say that it's
+
+4348
+02:38:21,600 --> 02:38:25,120
+it probably has to do with that as well
+
+4349
+02:38:23,760 --> 02:38:29,840
+maybe it's not enabled
+
+4350
+02:38:25,120 --> 02:38:29,840
+sorry about that yeah this is
+
+4351
+02:38:31,200 --> 02:38:35,200
+exactly there if you just search for
+
+4352
+02:38:33,840 --> 02:38:37,680
+sector it should be there
+
+4353
+02:38:35,200 --> 02:38:38,319
+yeah but i'm i'm yeah there's something
+
+4354
+02:38:37,680 --> 02:38:41,600
+that you can do
+
+4355
+02:38:38,318 --> 02:38:46,79
+talk about about later but it's uh
+
+4356
+02:38:41,600 --> 02:38:48,159
+just a sector so we have different one
+
+4357
+02:38:46,79 --> 02:38:49,680
+you did find that so if you there was
+
+4358
+02:38:48,159 --> 02:38:51,840
+one for finance you can just pick that
+
+4359
+02:38:49,680 --> 02:38:51,840
+yeah
+
+4360
+02:38:52,639 --> 02:38:57,519
+something else you can you can do and
+
+4361
+02:38:54,879 --> 02:38:59,39
+this one is important too it's it's
+
+4362
+02:38:57,520 --> 02:39:01,280
+going a bit further than the email so
+
+4363
+02:38:59,40 --> 02:39:02,560
+for example as a source we receive
+
+4364
+02:39:01,280 --> 02:39:04,79
+emails from various people
+
+4365
+02:39:02,559 --> 02:39:05,359
+i mean if i receive an email from i
+
+4366
+02:39:04,79 --> 02:39:05,920
+don't know from an analyst from i don't
+
+4367
+02:39:05,359 --> 02:39:08,720
+know
+
+4368
+02:39:05,920 --> 02:39:10,478
+he set mcafee and found that i'm working
+
+4369
+02:39:08,719 --> 02:39:12,719
+with them for years
+
+4370
+02:39:10,478 --> 02:39:13,679
+my confidence on this information is
+
+4371
+02:39:12,719 --> 02:39:16,79
+quite high
+
+4372
+02:39:13,680 --> 02:39:17,600
+on the other hand if i receive an email
+
+4373
+02:39:16,79 --> 02:39:19,39
+from someone unknown
+
+4374
+02:39:17,600 --> 02:39:20,880
+maybe my confidence will be a bit
+
+4375
+02:39:19,40 --> 02:39:22,479
+different so
+
+4376
+02:39:20,879 --> 02:39:24,478
+in myths you have plenty of taxonomies
+
+4377
+02:39:22,478 --> 02:39:26,239
+to express confidence
+
+4378
+02:39:24,478 --> 02:39:28,799
+for example the one that is actively
+
+4379
+02:39:26,239 --> 02:39:32,0
+9566.24 --> 9572
+used for empowering the military
+
+4380
+02:39:28,799 --> 02:39:34,799
+network is scale or nato scale
+
+4381
+02:39:32,0 --> 02:39:35,920
+9572 --> 9575.92
+where you can basically define the
+
+4382
+02:39:34,799 --> 02:39:37,438
+credibility of the
+
+4383
+02:39:35,920 --> 02:39:39,600
+of the source in this case we can say
+
+4384
+02:39:37,439 --> 02:39:40,639
+that we are we know the source and is
+
+4385
+02:39:39,600 --> 02:39:43,40
+usually really
+
+4386
+02:39:40,639 --> 02:39:45,358
+reliable so that's the source itself and
+
+4387
+02:39:43,40 --> 02:39:46,80
+we can say for this specific information
+
+4388
+02:39:45,359 --> 02:39:49,280
+that is
+
+4389
+02:39:46,79 --> 02:39:51,39
+um probably true
+
+4390
+02:39:49,280 --> 02:39:53,439
+because they send us some evidence now
+
+4391
+02:39:51,40 --> 02:39:53,760
+if i have like three emails taking about
+
+4392
+02:39:53,439 --> 02:39:57,840
+this
+
+4393
+02:39:53,760 --> 02:39:59,760
+talking about the same case maybe my
+
+4394
+02:39:57,840 --> 02:40:01,120
+level of credibility will increase
+
+4395
+02:39:59,760 --> 02:40:03,359
+because we have multiple people that
+
+4396
+02:40:01,120 --> 02:40:04,640
+have seen exactly the same kind of thing
+
+4397
+02:40:03,359 --> 02:40:07,120
+so in this case i will have those kind
+
+4398
+02:40:04,639 --> 02:40:07,920
+of information there again it's it's a
+
+4399
+02:40:07,120 --> 02:40:10,0
+9607.12 --> 9610
+way to
+
+4400
+02:40:07,920 --> 02:40:12,639
+really contextualize information and the
+
+4401
+02:40:10,0 --> 02:40:15,760
+9610 --> 9615.76
+quality of the information
+
+4402
+02:40:12,639 --> 02:40:17,599
+and you have for example
+
+4403
+02:40:15,760 --> 02:40:19,760
+additional one like for example we have
+
+4404
+02:40:17,600 --> 02:40:22,720
+one called estimative language
+
+4405
+02:40:19,760 --> 02:40:23,520
+so this one is more coming from dna and
+
+4406
+02:40:22,719 --> 02:40:25,599
+the cias
+
+4407
+02:40:23,520 --> 02:40:27,439
+it's like the likelihood of probability
+
+4408
+02:40:25,600 --> 02:40:28,960
+that this happen
+
+4409
+02:40:27,439 --> 02:40:30,720
+so we can say that this one has been
+
+4410
+02:40:28,959 --> 02:40:31,599
+almost certain and then we can even
+
+4411
+02:40:30,719 --> 02:40:34,639
+qualify
+
+4412
+02:40:31,600 --> 02:40:36,880
+or own an analytic judgment on this
+
+4413
+02:40:34,639 --> 02:40:37,680
+and i can say that it was like quickly
+
+4414
+02:40:36,879 --> 02:40:39,920
+done and it's
+
+4415
+02:40:37,680 --> 02:40:40,880
+not perfect i will just say low for
+
+4416
+02:40:39,920 --> 02:40:42,318
+example
+
+4417
+02:40:40,879 --> 02:40:43,920
+so then you can have this kind of
+
+4418
+02:40:42,318 --> 02:40:46,318
+information and you can
+
+4419
+02:40:43,920 --> 02:40:48,159
+either use it as an even level again or
+
+4420
+02:40:46,318 --> 02:40:50,0
+9646.319 --> 9650
+a specific review so for example if one
+
+4421
+02:40:48,159 --> 02:40:52,239
+of the emails it was like
+
+4422
+02:40:50,0 --> 02:40:54,159
+9650 --> 9654.16
+not properly collected or it was skirts
+
+4423
+02:40:52,239 --> 02:40:55,840
+or someone modified leather and so on
+
+4424
+02:40:54,159 --> 02:40:58,959
+maybe you can reduce
+
+4425
+02:40:55,840 --> 02:41:00,0
+9655.84 --> 9660
+the summative language of the confidence
+
+4426
+02:40:58,959 --> 02:41:02,0
+9658.96 --> 9662
+level that you have
+
+4427
+02:41:00,0 --> 02:41:03,359
+9660 --> 9663.359
+in the analytic judgment of the specific
+
+4428
+02:41:02,0 --> 02:41:06,79
+9662 --> 9666.08
+evidence or element
+
+4429
+02:41:03,359 --> 02:41:06,960
+by tagging that at attribute level so
+
+4430
+02:41:06,79 --> 02:41:08,239
+again
+
+4431
+02:41:06,959 --> 02:41:10,0
+9666.96 --> 9670
+those kind of information that we are
+
+4432
+02:41:08,239 --> 02:41:10,639
+putting there are factors and so on are
+
+4433
+02:41:10,0 --> 02:41:12,799
+9670 --> 9672.8
+more like
+
+4434
+02:41:10,639 --> 02:41:15,199
+even level but if you have really
+
+4435
+02:41:12,799 --> 02:41:17,278
+specific things that need to be changed
+
+4436
+02:41:15,200 --> 02:41:19,439
+or that are specific to the attribute or
+
+4437
+02:41:17,279 --> 02:41:24,239
+object then you can
+
+4438
+02:41:19,439 --> 02:41:24,239
+change it in the at the absolute level
+
+4439
+02:41:26,79 --> 02:41:29,200
+just some other thing on the user
+
+4440
+02:41:27,520 --> 02:41:31,120
+interface that might be useful too that
+
+4441
+02:41:29,200 --> 02:41:33,520
+we skipped
+
+4442
+02:41:31,120 --> 02:41:35,840
+on the metadata of the event you have
+
+4443
+02:41:33,520 --> 02:41:37,359
+plenty of information there
+
+4444
+02:41:35,840 --> 02:41:39,359
+why that is interesting regarding
+
+4445
+02:41:37,359 --> 02:41:40,960
+organization only and distribution
+
+4446
+02:41:39,359 --> 02:41:42,399
+in this case we just distribute to the
+
+4447
+02:41:40,959 --> 02:41:44,239
+organization but
+
+4448
+02:41:42,398 --> 02:41:45,920
+if you have pretty large even at some
+
+4449
+02:41:44,239 --> 02:41:47,760
+point in time and you want to distribute
+
+4450
+02:41:45,920 --> 02:41:49,359
+you have this kind of overview there
+
+4451
+02:41:47,760 --> 02:41:51,40
+which is helping you to
+
+4452
+02:41:49,359 --> 02:41:53,359
+see at which level you share this
+
+4453
+02:41:51,40 --> 02:41:55,200
+information in this case it's super easy
+
+4454
+02:41:53,359 --> 02:41:56,960
+we just distribute it to the training
+
+4455
+02:41:55,200 --> 02:41:58,960
+organization that's fine
+
+4456
+02:41:56,959 --> 02:42:00,879
+but if you have a pretty large instance
+
+4457
+02:41:58,959 --> 02:42:02,959
+with a lot of organization and so on
+
+4458
+02:42:00,879 --> 02:42:04,719
+it will display you a full graph of
+
+4459
+02:42:02,959 --> 02:42:07,759
+where the information will flow
+
+4460
+02:42:04,719 --> 02:42:07,760
+and will be distributed
+
+4461
+02:42:08,478 --> 02:42:12,239
+okay now going back to our event uh
+
+4462
+02:42:11,439 --> 02:42:13,840
+basically
+
+4463
+02:42:12,239 --> 02:42:15,520
+the reason why we went so deeply into
+
+4464
+02:42:13,840 --> 02:42:16,318
+the contextualization part is looking at
+
+4465
+02:42:15,520 --> 02:42:20,0
+9735.52 --> 9740
+this event
+
+4466
+02:42:16,318 --> 02:42:21,680
+we can already uh use this right away
+
+4467
+02:42:20,0 --> 02:42:22,639
+9740 --> 9742.64
+when feeding our tools when doing our
+
+4468
+02:42:21,680 --> 02:42:24,159
+searches
+
+4469
+02:42:22,639 --> 02:42:25,760
+to basically search for anything
+
+4470
+02:42:24,159 --> 02:42:26,478
+targeting the financial sector for
+
+4471
+02:42:25,760 --> 02:42:29,439
+example
+
+4472
+02:42:26,478 --> 02:42:30,159
+we can search for anything related to
+
+4473
+02:42:29,439 --> 02:42:33,359
+phishing
+
+4474
+02:42:30,159 --> 02:42:35,119
+and find the data contained in this
+
+4475
+02:42:33,359 --> 02:42:37,600
+particular event so this already helps
+
+4476
+02:42:35,120 --> 02:42:41,40
+us with our filtering mechanisms
+
+4477
+02:42:37,600 --> 02:42:42,960
+as for pap and tlp those
+
+4478
+02:42:41,40 --> 02:42:45,120
+tags we can use when we make decisions
+
+4479
+02:42:42,959 --> 02:42:47,438
+on which tools we feed
+
+4480
+02:42:45,120 --> 02:42:49,279
+the data to or which partners we share
+
+4481
+02:42:47,439 --> 02:42:49,840
+the information within the case of tlp
+
+4482
+02:42:49,279 --> 02:42:51,200
+so
+
+4483
+02:42:49,840 --> 02:42:52,719
+we're going to see that more tomorrow
+
+4484
+02:42:51,200 --> 02:42:54,319
+when we're creating synchronization
+
+4485
+02:42:52,719 --> 02:42:57,278
+links with other instances
+
+4486
+02:42:54,318 --> 02:42:57,920
+we can for example set restrictions on
+
+4487
+02:42:57,279 --> 02:43:00,79
+tlp
+
+4488
+02:42:57,920 --> 02:43:01,600
+when we're pushing data to another node
+
+4489
+02:43:00,79 --> 02:43:04,159
+and we can say okay
+
+4490
+02:43:01,600 --> 02:43:06,0
+9781.6 --> 9786
+no matter what distribution setting
+
+4491
+02:43:04,159 --> 02:43:07,520
+don't send anything tlp amber in this
+
+4492
+02:43:06,0 --> 02:43:09,439
+9786 --> 9789.439
+direction for example
+
+4493
+02:43:07,520 --> 02:43:11,279
+yeah as an example as an example there's
+
+4494
+02:43:09,439 --> 02:43:12,398
+a very good open source tool um called
+
+4495
+02:43:11,279 --> 02:43:15,520
+the hive
+
+4496
+02:43:12,398 --> 02:43:17,119
+for serending and they use pap to
+
+4497
+02:43:15,520 --> 02:43:19,120
+know which kind of actions they can do
+
+4498
+02:43:17,120 --> 02:43:22,560
+on the data so if you synchronize them
+
+4499
+02:43:19,120 --> 02:43:25,680
+with the hive instance you can
+
+4500
+02:43:22,559 --> 02:43:28,318
+really be sure that what you set
+
+4501
+02:43:25,680 --> 02:43:29,120
+as pep for example red on the lisp
+
+4502
+02:43:28,318 --> 02:43:30,959
+instance
+
+4503
+02:43:29,120 --> 02:43:33,120
+will not generate issues when you are
+
+4504
+02:43:30,959 --> 02:43:35,438
+starting to expansion within
+
+4505
+02:43:33,120 --> 02:43:37,359
+cortex on the ice to be sure that the
+
+4506
+02:43:35,439 --> 02:43:40,559
+information is not basically flowing
+
+4507
+02:43:37,359 --> 02:43:42,880
+somewhere else so at this point
+
+4508
+02:43:40,559 --> 02:43:43,840
+something that we didn't do so far is we
+
+4509
+02:43:42,879 --> 02:43:45,839
+did not include the
+
+4510
+02:43:43,840 --> 02:43:47,680
+on the initial email so what we're going
+
+4511
+02:43:45,840 --> 02:43:48,960
+to do now is we're going to use another
+
+4512
+02:43:47,680 --> 02:43:51,200
+functionality of this that we haven't
+
+4513
+02:43:48,959 --> 02:43:54,79
+talked much about called the report
+
+4514
+02:43:51,200 --> 02:43:55,760
+the event report we can also include
+
+4515
+02:43:54,79 --> 02:43:58,639
+clear text
+
+4516
+02:43:55,760 --> 02:44:00,398
+information such as a report description
+
+4517
+02:43:58,639 --> 02:44:01,599
+and so on together with the event
+
+4518
+02:44:00,398 --> 02:44:03,439
+so what we're going to do now is
+
+4519
+02:44:01,600 --> 02:44:05,200
+something very simple we're not going to
+
+4520
+02:44:03,439 --> 02:44:06,720
+write our own report we have a report
+
+4521
+02:44:05,200 --> 02:44:07,439
+already available from the original
+
+4522
+02:44:06,719 --> 02:44:09,119
+source
+
+4523
+02:44:07,439 --> 02:44:11,439
+so we're just going to paste that entire
+
+4524
+02:44:09,120 --> 02:44:11,439
+email
+
+4525
+02:44:14,398 --> 02:44:19,840
+okay just submit for now
+
+4526
+02:44:21,579 --> 02:44:24,770
+[Music]
+
+4527
+02:44:26,239 --> 02:44:29,920
+so now if you look at our email
+
+4528
+02:44:30,318 --> 02:44:34,0
+9870.319 --> 9874
+report we just have a simple report
+
+4529
+02:44:31,920 --> 02:44:35,359
+during gear text we're going to see an
+
+4530
+02:44:34,0 --> 02:44:36,879
+9874 --> 9876.88
+example what you can do with this so
+
+4531
+02:44:35,359 --> 02:44:39,359
+this is all in markdown
+
+4532
+02:44:36,879 --> 02:44:41,438
+so you could go into edit mode and
+
+4533
+02:44:39,359 --> 02:44:41,920
+pretty it up add additional information
+
+4534
+02:44:41,439 --> 02:44:43,600
+there
+
+4535
+02:44:41,920 --> 02:44:45,40
+we're not going to do that now because
+
+4536
+02:44:43,600 --> 02:44:46,0
+9883.6 --> 9886
+we're going to just look at an example
+
+4537
+02:44:45,40 --> 02:44:47,920
+that already has that
+
+4538
+02:44:46,0 --> 02:44:49,520
+9886 --> 9889.52
+but before we do that let's get back to
+
+4539
+02:44:47,920 --> 02:44:51,279
+our event and let's assume that we're
+
+4540
+02:44:49,520 --> 02:44:51,680
+done with it with this entire process we
+
+4541
+02:44:51,279 --> 02:44:53,520
+have our
+
+4542
+02:44:51,680 --> 02:44:54,800
+report we have our event we have
+
+4543
+02:44:53,520 --> 02:44:56,560
+contextualized all
+
+4544
+02:44:54,799 --> 02:44:57,920
+our data and let's publish it now to the
+
+4545
+02:44:56,559 --> 02:44:59,840
+community
+
+4546
+02:44:57,920 --> 02:45:01,520
+so when it comes to publishing we have
+
+4547
+02:44:59,840 --> 02:45:05,120
+different uh
+
+4548
+02:45:01,520 --> 02:45:06,720
+uh ways of achieving that ms by default
+
+4549
+02:45:05,120 --> 02:45:08,640
+when we create an event like this at
+
+4550
+02:45:06,719 --> 02:45:10,159
+this stage we have all the data
+
+4551
+02:45:08,639 --> 02:45:11,439
+contained that we want to share out and
+
+4552
+02:45:10,159 --> 02:45:13,520
+that we want to use
+
+4553
+02:45:11,439 --> 02:45:14,639
+however misconsiders this to be
+
+4554
+02:45:13,520 --> 02:45:17,279
+non-final
+
+4555
+02:45:14,639 --> 02:45:19,358
+it is not to be used by automation tools
+
+4556
+02:45:17,279 --> 02:45:20,960
+connected to this
+
+4557
+02:45:19,359 --> 02:45:22,479
+it is not going to be synchronized out
+
+4558
+02:45:20,959 --> 02:45:25,759
+to other instances
+
+4559
+02:45:22,478 --> 02:45:28,959
+and uh and so on
+
+4560
+02:45:25,760 --> 02:45:31,279
+what we can do now is first of all
+
+4561
+02:45:28,959 --> 02:45:34,318
+we need to decide how we shared it out
+
+4562
+02:45:31,279 --> 02:45:35,840
+it is the organization only for now
+
+4563
+02:45:34,318 --> 02:45:38,639
+so even if we were to publish it it
+
+4564
+02:45:35,840 --> 02:45:40,719
+would still only be pushed to our own
+
+4565
+02:45:38,639 --> 02:45:42,239
+tools that connect to our miss but it
+
+4566
+02:45:40,719 --> 02:45:44,159
+would not be made visible to other
+
+4567
+02:45:42,239 --> 02:45:45,119
+organizations but we want to change this
+
+4568
+02:45:44,159 --> 02:45:48,0
+9944.16 --> 9948
+in this case
+
+4569
+02:45:45,120 --> 02:45:49,520
+however let's assume that uh that when
+
+4570
+02:45:48,0 --> 02:45:52,398
+9948 --> 9952.399
+we're an organization
+
+4571
+02:45:49,520 --> 02:45:53,840
+that does not wish to reveal who we uh
+
+4572
+02:45:52,398 --> 02:45:56,159
+that we were involved in
+
+4573
+02:45:53,840 --> 02:45:58,239
+in this entire incident we just want to
+
+4574
+02:45:56,159 --> 02:46:00,318
+entrust the third party with doing it
+
+4575
+02:45:58,239 --> 02:46:01,600
+so as you see there where alex is
+
+4576
+02:46:00,318 --> 02:46:02,318
+hovering we basically have several
+
+4577
+02:46:01,600 --> 02:46:03,840
+options here
+
+4578
+02:46:02,318 --> 02:46:06,559
+we can either publish the event which
+
+4579
+02:46:03,840 --> 02:46:08,79
+means we initiate the entire exchange
+
+4580
+02:46:06,559 --> 02:46:10,559
+with other instances if the
+
+4581
+02:46:08,79 --> 02:46:12,159
+distribution allows it it will it will
+
+4582
+02:46:10,559 --> 02:46:12,719
+alert everyone that we have published
+
+4583
+02:46:12,159 --> 02:46:14,799
+this
+
+4584
+02:46:12,719 --> 02:46:16,478
+or alternatively we can we can delegate
+
+4585
+02:46:14,799 --> 02:46:18,159
+the publishing to third party and stay
+
+4586
+02:46:16,478 --> 02:46:20,879
+anonymous ourselves so let's do that
+
+4587
+02:46:18,159 --> 02:46:22,159
+option for now
+
+4588
+02:46:20,879 --> 02:46:24,0
+9980.88 --> 9984
+so what we're doing now is we're
+
+4589
+02:46:22,159 --> 02:46:26,478
+entrusting a third party to take over
+
+4590
+02:46:24,0 --> 02:46:28,559
+9984 --> 9988.56
+this event for us so let's say that we
+
+4591
+02:46:26,478 --> 02:46:30,478
+would entrust for example circle to take
+
+4592
+02:46:28,559 --> 02:46:32,398
+over this event
+
+4593
+02:46:30,478 --> 02:46:34,79
+and we tell circle that we want to share
+
+4594
+02:46:32,398 --> 02:46:36,840
+this event to be shared with
+
+4595
+02:46:34,79 --> 02:46:39,840
+uh the entire community so we've
+
+4596
+02:46:36,840 --> 02:46:39,840
+collected
+
+4597
+02:46:45,600 --> 02:46:49,359
+yeah you can see this community only for
+
+4598
+02:46:47,359 --> 02:46:50,840
+example or a sharing group whatever you
+
+4599
+02:46:49,359 --> 02:46:53,520
+prefer
+
+4600
+02:46:50,840 --> 02:46:55,279
+okay so this is again a suggestion to
+
+4601
+02:46:53,520 --> 02:46:56,960
+the other organization saying okay we
+
+4602
+02:46:55,279 --> 02:46:57,760
+want you to share this out and we want
+
+4603
+02:46:56,959 --> 02:47:00,959
+you to share this
+
+4604
+02:46:57,760 --> 02:47:02,0
+10017.76 --> 10022
+to this community once we click yes
+
+4605
+02:47:00,959 --> 02:47:04,0
+10020.96 --> 10024
+even though the event was your
+
+4606
+02:47:02,0 --> 02:47:05,439
+10022 --> 10025.439
+organizational and only visible to us
+
+4607
+02:47:04,0 --> 02:47:07,680
+10024 --> 10027.68
+it now becomes visible to two
+
+4608
+02:47:05,439 --> 02:47:08,960
+organizations ourselves
+
+4609
+02:47:07,680 --> 02:47:10,720
+and the other organization that we
+
+4610
+02:47:08,959 --> 02:47:12,0
+10028.96 --> 10032
+entrust in this case circle so circle
+
+4611
+02:47:10,719 --> 02:47:14,318
+would get an email
+
+4612
+02:47:12,0 --> 02:47:16,79
+10032 --> 10036.08
+saying okay there's this delegation
+
+4613
+02:47:14,318 --> 02:47:17,119
+request someone wants you to take over
+
+4614
+02:47:16,79 --> 02:47:18,398
+their event
+
+4615
+02:47:17,120 --> 02:47:19,920
+are you willing to take it over and
+
+4616
+02:47:18,398 --> 02:47:21,199
+publish it under your name this will
+
+4617
+02:47:19,920 --> 02:47:23,120
+look something like this with slightly
+
+4618
+02:47:21,200 --> 02:47:25,920
+different text we're cheating here now
+
+4619
+02:47:23,120 --> 02:47:27,600
+since we're doing a training we're site
+
+4620
+02:47:25,920 --> 02:47:28,478
+administrators and we see both sides of
+
+4621
+02:47:27,600 --> 02:47:30,239
+the story
+
+4622
+02:47:28,478 --> 02:47:31,599
+so we can either accept or discard this
+
+4623
+02:47:30,239 --> 02:47:33,920
+request keep in mind
+
+4624
+02:47:31,600 --> 02:47:35,200
+if you accept such a request the event
+
+4625
+02:47:33,920 --> 02:47:38,559
+becomes your event
+
+4626
+02:47:35,200 --> 02:47:40,960
+a copy of it is created under your name
+
+4627
+02:47:38,559 --> 02:47:42,639
+and basically you are taking
+
+4628
+02:47:40,959 --> 02:47:44,239
+responsibility for the event from down
+
+4629
+02:47:42,639 --> 02:47:46,719
+so also make sure that you're not
+
+4630
+02:47:44,239 --> 02:47:49,39
+pushing junk under your name so in this
+
+4631
+02:47:46,719 --> 02:47:50,799
+case let's just discard it
+
+4632
+02:47:49,40 --> 02:47:53,920
+but we could have accepted it and then
+
+4633
+02:47:50,799 --> 02:47:57,358
+it would have become our event
+
+4634
+02:47:53,920 --> 02:47:57,359
+okay let's go back to the event
+
+4635
+02:48:00,79 --> 02:48:04,719
+okay so now the other alternative is if
+
+4636
+02:48:03,200 --> 02:48:06,240
+you want to publish it under our name
+
+4637
+02:48:04,719 --> 02:48:07,840
+what you would need to do is you would
+
+4638
+02:48:06,239 --> 02:48:08,398
+need to raise the distribution level
+
+4639
+02:48:07,840 --> 02:48:10,639
+first
+
+4640
+02:48:08,398 --> 02:48:11,599
+if you wanted to uh to involve any other
+
+4641
+02:48:10,639 --> 02:48:13,39
+parties
+
+4642
+02:48:11,600 --> 02:48:15,680
+so we need to edit the event in that
+
+4643
+02:48:13,40 --> 02:48:18,240
+case and raise the distribution level to
+
+4644
+02:48:15,680 --> 02:48:19,439
+say this community or connected
+
+4645
+02:48:18,239 --> 02:48:20,318
+communities let's go with connected
+
+4646
+02:48:19,439 --> 02:48:22,639
+communities
+
+4647
+02:48:20,318 --> 02:48:24,639
+connected communities means anyone that
+
+4648
+02:48:22,639 --> 02:48:26,478
+has access to my miss pinsons
+
+4649
+02:48:24,639 --> 02:48:28,478
+and all the directly interconnected
+
+4650
+02:48:26,478 --> 02:48:29,199
+instances including all their members as
+
+4651
+02:48:28,478 --> 02:48:32,478
+well
+
+4652
+02:48:29,200 --> 02:48:33,920
+so in the case for example
+
+4653
+02:48:32,478 --> 02:48:36,239
+of us publishing something like this in
+
+4654
+02:48:33,920 --> 02:48:37,439
+the first instance we as circle have our
+
+4655
+02:48:36,239 --> 02:48:39,439
+instance connected to it
+
+4656
+02:48:37,439 --> 02:48:40,960
+so all the members of the circle
+
+4657
+02:48:39,439 --> 02:48:42,800
+instance will automatically also be
+
+4658
+02:48:40,959 --> 02:48:46,79
+included in the exchange here we see a
+
+4659
+02:48:42,799 --> 02:48:47,759
+graph of that so we see the event would
+
+4660
+02:48:46,79 --> 02:48:49,279
+be also visible to all the directly
+
+4661
+02:48:47,760 --> 02:48:51,120
+connected instances
+
+4662
+02:48:49,279 --> 02:48:53,40
+which we only have one of which is a
+
+4663
+02:48:51,120 --> 02:48:56,640
+loopback
+
+4664
+02:48:53,40 --> 02:48:57,520
+connection to exchange so not that
+
+4665
+02:48:56,639 --> 02:48:59,119
+interesting
+
+4666
+02:48:57,520 --> 02:49:00,960
+and to everyone that has access to this
+
+4667
+02:48:59,120 --> 02:49:04,160
+current instance
+
+4668
+02:49:00,959 --> 02:49:04,639
+okay once we're done we can click
+
+4669
+02:49:04,159 --> 02:49:08,159
+publish
+
+4670
+02:49:04,639 --> 02:49:08,159
+and then the event gets synchronized
+
+4671
+02:49:08,639 --> 02:49:12,0
+10148.64 --> 10152
+so what happens at this stage is first
+
+4672
+02:49:10,639 --> 02:49:14,799
+of all the event will jump
+
+4673
+02:49:12,0 --> 02:49:16,559
+10152 --> 10156.56
+over to directly connected instances
+
+4674
+02:49:14,799 --> 02:49:18,239
+miss will send out a bunch of emails to
+
+4675
+02:49:16,559 --> 02:49:20,559
+everyone that subscribes to
+
+4676
+02:49:18,239 --> 02:49:22,959
+publish alerts that there is a new event
+
+4677
+02:49:20,559 --> 02:49:25,760
+with all the data contained within
+
+4678
+02:49:22,959 --> 02:49:27,759
+it will push the event down various
+
+4679
+02:49:25,760 --> 02:49:32,478
+local channels to other tools
+
+4680
+02:49:27,760 --> 02:49:34,0
+10167.76 --> 10174
+using xeromq kafka and so on and syslog
+
+4681
+02:49:32,478 --> 02:49:35,679
+so if you have any tools that are
+
+4682
+02:49:34,0 --> 02:49:37,600
+10174 --> 10177.6
+subscribed to these
+
+4683
+02:49:35,680 --> 02:49:38,800
+published feeds and they will ingest the
+
+4684
+02:49:37,600 --> 02:49:40,559
+data
+
+4685
+02:49:38,799 --> 02:49:42,478
+and it will also make it available to
+
+4686
+02:49:40,559 --> 02:49:44,0
+10180.56 --> 10184
+the api and to make it available to all
+
+4687
+02:49:42,478 --> 02:49:47,119
+the integration
+
+4688
+02:49:44,0 --> 02:49:49,359
+10184 --> 10189.359
+tools out there so if you have your
+
+4689
+02:49:47,120 --> 02:49:51,359
+your scene connected to miss it will now
+
+4690
+02:49:49,359 --> 02:49:54,559
+be able to fetch the data
+
+4691
+02:49:51,359 --> 02:49:55,200
+contained in this event so this is
+
+4692
+02:49:54,559 --> 02:49:57,600
+basically
+
+4693
+02:49:55,200 --> 02:49:58,319
+the publishing process however there is
+
+4694
+02:49:57,600 --> 02:50:00,79
+uh
+
+4695
+02:49:58,318 --> 02:50:01,840
+if at this point we noticed that okay
+
+4696
+02:50:00,79 --> 02:50:03,600
+we've now shared this event out
+
+4697
+02:50:01,840 --> 02:50:06,840
+but we've actually made a typo in the
+
+4698
+02:50:03,600 --> 02:50:10,0
+10203.6 --> 10210
+title we we wanted to include
+
+4699
+02:50:06,840 --> 02:50:13,760
+uh um i don't know
+
+4700
+02:50:10,0 --> 02:50:16,239
+10210 --> 10216.24
+a trailing period at the end of the
+
+4701
+02:50:13,760 --> 02:50:16,239
+sentence
+
+4702
+02:50:19,279 --> 02:50:23,279
+in the title and we edit the event what
+
+4703
+02:50:21,439 --> 02:50:24,639
+happens now is there is a modification
+
+4704
+02:50:23,279 --> 02:50:26,800
+to the event so even though it was
+
+4705
+02:50:24,639 --> 02:50:30,79
+published it becomes unpublished again
+
+4706
+02:50:26,799 --> 02:50:31,920
+and it needs to be to be republished now
+
+4707
+02:50:30,79 --> 02:50:33,760
+the reason why we do this is
+
+4708
+02:50:31,920 --> 02:50:37,680
+uh whenever there is a change we need to
+
+4709
+02:50:33,760 --> 02:50:39,920
+synchronize it out to
+
+4710
+02:50:37,680 --> 02:50:40,720
+and if you have a publishing process in
+
+4711
+02:50:39,920 --> 02:50:42,478
+place where
+
+4712
+02:50:40,719 --> 02:50:44,159
+so only certain users have access to
+
+4713
+02:50:42,478 --> 02:50:45,760
+publishing rights for example
+
+4714
+02:50:44,159 --> 02:50:47,359
+then anytime your organization is
+
+4715
+02:50:45,760 --> 02:50:49,120
+pushing out information
+
+4716
+02:50:47,359 --> 02:50:50,800
+it can go through the irregular vetting
+
+4717
+02:50:49,120 --> 02:50:52,319
+process so any change will unset the
+
+4718
+02:50:50,799 --> 02:50:54,318
+publishing of the event
+
+4719
+02:50:52,318 --> 02:50:55,840
+now in this case this is a very small
+
+4720
+02:50:54,318 --> 02:50:57,519
+change that we've made so we don't want
+
+4721
+02:50:55,840 --> 02:50:59,920
+to actually send out events to all their
+
+4722
+02:50:57,520 --> 02:51:03,40
+users we don't want to spam them with
+
+4723
+02:50:59,920 --> 02:51:03,920
+data that is pretty relevant for them so
+
+4724
+02:51:03,40 --> 02:51:05,520
+we can publish
+
+4725
+02:51:03,920 --> 02:51:09,279
+do the publishing again but this time
+
+4726
+02:51:05,520 --> 02:51:11,40
+using the publish no email option
+
+4727
+02:51:09,279 --> 02:51:12,640
+so it will also synchronize the data it
+
+4728
+02:51:11,40 --> 02:51:13,439
+will again make it available to all
+
+4729
+02:51:12,639 --> 02:51:16,318
+different
+
+4730
+02:51:13,439 --> 02:51:19,600
+means of ingesting the data but it will
+
+4731
+02:51:16,318 --> 02:51:22,159
+not spam our users with emails
+
+4732
+02:51:19,600 --> 02:51:23,120
+okay so that's basically it for the
+
+4733
+02:51:22,159 --> 02:51:24,398
+publishing
+
+4734
+02:51:23,120 --> 02:51:26,399
+and perhaps one thing that is
+
+4735
+02:51:24,398 --> 02:51:27,680
+interesting and that we didn't talk much
+
+4736
+02:51:26,398 --> 02:51:29,119
+about is
+
+4737
+02:51:27,680 --> 02:51:30,479
+we have now raised the distribution
+
+4738
+02:51:29,120 --> 02:51:31,520
+level of this event to connected
+
+4739
+02:51:30,478 --> 02:51:34,79
+communities
+
+4740
+02:51:31,520 --> 02:51:35,439
+so the event is synchronized out but we
+
+4741
+02:51:34,79 --> 02:51:36,398
+actually had an attribute if you look
+
+4742
+02:51:35,439 --> 02:51:37,760
+further down
+
+4743
+02:51:36,398 --> 02:51:40,398
+that's had a different distribution
+
+4744
+02:51:37,760 --> 02:51:41,840
+level uh so that one is actually going
+
+4745
+02:51:40,398 --> 02:51:43,39
+to be removed from the synchronized
+
+4746
+02:51:41,840 --> 02:51:45,520
+button
+
+4747
+02:51:43,40 --> 02:51:49,279
+uh so we had one that the the
+
+4748
+02:51:45,520 --> 02:51:49,279
+impersonated person's email address
+
+4749
+02:51:49,359 --> 02:51:52,0
+10309.359 --> 10312
+that was set to organization only so
+
+4750
+02:51:51,40 --> 02:51:53,120
+whenever we're talking about
+
+4751
+02:51:52,0 --> 02:51:54,639
+10312 --> 10314.64
+synchronization
+
+4752
+02:51:53,120 --> 02:51:56,479
+that thing will in this case not
+
+4753
+02:51:54,639 --> 02:51:59,39
+synchronize out so that will be redacted
+
+4754
+02:51:56,478 --> 02:51:59,39
+from the event
+
+4755
+02:51:59,279 --> 02:52:03,680
+okay something else that we can do at
+
+4756
+02:52:02,239 --> 02:52:05,520
+this point once we have created our
+
+4757
+02:52:03,680 --> 02:52:06,960
+event is we can also extract it in
+
+4758
+02:52:05,520 --> 02:52:09,40
+different formats so if you click on
+
+4759
+02:52:06,959 --> 02:52:10,398
+download s on the left side
+
+4760
+02:52:09,40 --> 02:52:12,80
+you will see that we can basically
+
+4761
+02:52:10,398 --> 02:52:13,519
+convert this automatically to a bunch of
+
+4762
+02:52:12,79 --> 02:52:14,799
+different formats and extract it in
+
+4763
+02:52:13,520 --> 02:52:16,560
+those formats directly
+
+4764
+02:52:14,799 --> 02:52:18,639
+this is also what we would be accessing
+
+4765
+02:52:16,559 --> 02:52:20,959
+by the api if you were to search for
+
+4766
+02:52:18,639 --> 02:52:23,519
+this event we can also mark whatever
+
+4767
+02:52:20,959 --> 02:52:25,199
+response format we want just very
+
+4768
+02:52:23,520 --> 02:52:26,560
+briefly we won't go very deeply into
+
+4769
+02:52:25,200 --> 02:52:30,0
+10345.2 --> 10350
+this these formats
+
+4770
+02:52:26,559 --> 02:52:31,600
+are coming partially from our predefined
+
+4771
+02:52:30,0 --> 02:52:33,520
+10350 --> 10353.52
+hard-coded list of formats that we
+
+4772
+02:52:31,600 --> 02:52:35,600
+support in miss
+
+4773
+02:52:33,520 --> 02:52:36,800
+but some of these formats also come from
+
+4774
+02:52:35,600 --> 02:52:40,0
+10355.6 --> 10360
+the different exp
+
+4775
+02:52:36,799 --> 02:52:41,920
+export modules that we have so if you
+
+4776
+02:52:40,0 --> 02:52:43,439
+10360 --> 10363.439
+want you can either build your own
+
+4777
+02:52:41,920 --> 02:52:44,799
+native modules for exporting and
+
+4778
+02:52:43,439 --> 02:52:47,840
+converting data
+
+4779
+02:52:44,799 --> 02:52:50,159
+or you can build modules
+
+4780
+02:52:47,840 --> 02:52:51,279
+that are sitting in another tool called
+
+4781
+02:52:50,159 --> 02:52:53,39
+miss modules
+
+4782
+02:52:51,279 --> 02:52:54,560
+side by side with mist that will ingest
+
+4783
+02:52:53,40 --> 02:52:55,439
+the data and then convert it to other
+
+4784
+02:52:54,559 --> 02:52:58,159
+formats
+
+4785
+02:52:55,439 --> 02:53:00,0
+10375.439 --> 10380
+so here's a pdf report that was created
+
+4786
+02:52:58,159 --> 02:53:03,439
+directly out of the event
+
+4787
+02:53:00,0 --> 02:53:05,680
+10380 --> 10385.68
+uh and that you can just
+
+4788
+02:53:03,439 --> 02:53:07,40
+share out directly from the event
+
+4789
+02:53:05,680 --> 02:53:09,600
+something else that you can do
+
+4790
+02:53:07,40 --> 02:53:11,520
+is uh anything that we do in misp so all
+
+4791
+02:53:09,600 --> 02:53:13,760
+the process of adding attributes
+
+4792
+02:53:11,520 --> 02:53:14,720
+all the process of viewing data you can
+
+4793
+02:53:13,760 --> 02:53:16,478
+also do uh
+
+4794
+02:53:14,719 --> 02:53:18,318
+so do that in a machine partial way by
+
+4795
+02:53:16,478 --> 02:53:19,920
+just spending.json at the end of any of
+
+4796
+02:53:18,318 --> 02:53:21,278
+the url
+
+4797
+02:53:19,920 --> 02:53:23,120
+so in that case in this event we're
+
+4798
+02:53:21,279 --> 02:53:23,680
+going to get the json representation of
+
+4799
+02:53:23,120 --> 02:53:27,760
+the
+
+4800
+02:53:23,680 --> 02:53:27,760
+event okay
+
+4801
+02:53:28,79 --> 02:53:32,318
+so that's basically for creating an
+
+4802
+02:53:30,0 --> 02:53:32,318
+10410 --> 10412.319
+event
+
+4803
+02:53:33,359 --> 02:53:36,720
+just maybe one thing that is interesting
+
+4804
+02:53:35,40 --> 02:53:40,80
+we have a very good question from
+
+4805
+02:53:36,719 --> 02:53:43,119
+martin it's a
+
+4806
+02:53:40,79 --> 02:53:46,239
+quite complex one but maybe we can
+
+4807
+02:53:43,120 --> 02:53:49,520
+already partially answer it
+
+4808
+02:53:46,239 --> 02:53:50,959
+so when you create an event and in this
+
+4809
+02:53:49,520 --> 02:53:54,79
+case a creator or
+
+4810
+02:53:50,959 --> 02:53:55,199
+is the training people can contribute on
+
+4811
+02:53:54,79 --> 02:53:57,680
+that one
+
+4812
+02:53:55,200 --> 02:53:59,520
+but if you have an isaac and you want to
+
+4813
+02:53:57,680 --> 02:54:00,318
+distribute back the information and so
+
+4814
+02:53:59,520 --> 02:54:02,560
+on
+
+4815
+02:54:00,318 --> 02:54:04,559
+one of the options that you have is to
+
+4816
+02:54:02,559 --> 02:54:05,760
+try to create extended events for
+
+4817
+02:54:04,559 --> 02:54:08,879
+example out of it
+
+4818
+02:54:05,760 --> 02:54:10,398
+so you can um out of an event you can
+
+4819
+02:54:08,879 --> 02:54:13,358
+create a new one
+
+4820
+02:54:10,398 --> 02:54:14,478
+um which would be for example with
+
+4821
+02:54:13,359 --> 02:54:18,0
+10453.359 --> 10458
+additional information
+
+4822
+02:54:14,478 --> 02:54:18,959
+like validations uh additional things
+
+4823
+02:54:18,0 --> 02:54:21,520
+10458 --> 10461.52
+that you want you
+
+4824
+02:54:18,959 --> 02:54:22,799
+you want to add so you have this kind of
+
+4825
+02:54:21,520 --> 02:54:24,159
+extend even and you will create
+
+4826
+02:54:22,799 --> 02:54:27,358
+automatically a
+
+4827
+02:54:24,159 --> 02:54:33,920
+new event based on that
+
+4828
+02:54:27,359 --> 02:54:34,800
+um thing that is interesting there um
+
+4829
+02:54:33,920 --> 02:54:36,559
+the
+
+4830
+02:54:34,799 --> 02:54:38,398
+the thing is you can really create
+
+4831
+02:54:36,559 --> 02:54:40,398
+something completely new
+
+4832
+02:54:38,398 --> 02:54:42,239
+out of it and then see so for example
+
+4833
+02:54:40,398 --> 02:54:45,358
+for this case i can say that we
+
+4834
+02:54:42,239 --> 02:54:47,279
+uh we did a kind of session with
+
+4835
+02:54:45,359 --> 02:54:50,0
+10485.359 --> 10490
+additional information
+
+4836
+02:54:47,279 --> 02:54:52,960
+um there the distribution is your
+
+4837
+02:54:50,0 --> 02:54:52,959
+10490 --> 10492.96
+organization only
+
+4838
+02:54:53,120 --> 02:54:57,680
+and i would add for example a specific
+
+4839
+02:54:55,600 --> 02:55:02,159
+attribute
+
+4840
+02:54:57,680 --> 02:55:05,600
+which is for example targeting data
+
+4841
+02:55:02,159 --> 02:55:09,359
+and i can say target user uh the son
+
+4842
+02:55:05,600 --> 02:55:11,439
+of the prime minister
+
+4843
+02:55:09,359 --> 02:55:12,479
+so it may be information that you really
+
+4844
+02:55:11,439 --> 02:55:16,159
+don't want to share
+
+4845
+02:55:12,478 --> 02:55:18,159
+with others so this one is basically
+
+4846
+02:55:16,159 --> 02:55:19,200
+a normal event with additional
+
+4847
+02:55:18,159 --> 02:55:21,760
+information there
+
+4848
+02:55:19,200 --> 02:55:24,79
+and it's only shared within your
+
+4849
+02:55:21,760 --> 02:55:26,239
+organization
+
+4850
+02:55:24,79 --> 02:55:27,600
+nevertheless if you go to the original
+
+4851
+02:55:26,239 --> 02:55:29,119
+event
+
+4852
+02:55:27,600 --> 02:55:31,279
+you have this kind of extended view
+
+4853
+02:55:29,120 --> 02:55:35,279
+there and we can have
+
+4854
+02:55:31,279 --> 02:55:38,560
+what we call an extended view and not an
+
+4855
+02:55:35,279 --> 02:55:41,600
+atomic view and the two information
+
+4856
+02:55:38,559 --> 02:55:43,760
+so the is combined and you can see there
+
+4857
+02:55:41,600 --> 02:55:46,159
+that we have one with the information
+
+4858
+02:55:43,760 --> 02:55:49,760
+about the son of the prime minister
+
+4859
+02:55:46,159 --> 02:55:52,478
+which is the extended event there so
+
+4860
+02:55:49,760 --> 02:55:53,200
+just to answer the question of martin
+
+4861
+02:55:52,478 --> 02:55:56,559
+about
+
+4862
+02:55:53,200 --> 02:55:58,880
+the question about
+
+4863
+02:55:56,559 --> 02:56:00,239
+adding information on existing event is
+
+4864
+02:55:58,879 --> 02:56:03,278
+one way of doing it
+
+4865
+02:56:00,239 --> 02:56:05,840
+so using extended event is a way to
+
+4866
+02:56:03,279 --> 02:56:07,200
+qualify or extend even with additional
+
+4867
+02:56:05,840 --> 02:56:09,600
+information and so on
+
+4868
+02:56:07,200 --> 02:56:10,479
+um it's actively used for example for
+
+4869
+02:56:09,600 --> 02:56:12,559
+when you have
+
+4870
+02:56:10,478 --> 02:56:14,318
+two different view of the information
+
+4871
+02:56:12,559 --> 02:56:15,519
+because one is distributed and another
+
+4872
+02:56:14,318 --> 02:56:17,920
+one is like
+
+4873
+02:56:15,520 --> 02:56:19,120
+likely like the private information like
+
+4874
+02:56:17,920 --> 02:56:21,120
+the forensic evidence
+
+4875
+02:56:19,120 --> 02:56:22,800
+that you cannot share for example you
+
+4876
+02:56:21,120 --> 02:56:24,399
+can create this kind of thing
+
+4877
+02:56:22,799 --> 02:56:25,599
+it's one way of doing it it's not
+
+4878
+02:56:24,398 --> 02:56:26,959
+answering companies the question of
+
+4879
+02:56:25,600 --> 02:56:29,439
+martin but we can
+
+4880
+02:56:26,959 --> 02:56:31,358
+even go deeper later on that but it's
+
+4881
+02:56:29,439 --> 02:56:32,559
+it's one way of
+
+4882
+02:56:31,359 --> 02:56:34,559
+because tomorrow we talk about
+
+4883
+02:56:32,559 --> 02:56:36,0
+10592.56 --> 10596
+synchronization there are some specific
+
+4884
+02:56:34,559 --> 02:56:37,920
+options for isaac like
+
+4885
+02:56:36,0 --> 02:56:39,359
+10596 --> 10599.359
+and publishing events if we do
+
+4886
+02:56:37,920 --> 02:56:41,439
+synchronization and so on
+
+4887
+02:56:39,359 --> 02:56:43,200
+that can be used in some some cases for
+
+4888
+02:56:41,439 --> 02:56:45,520
+isaac's
+
+4889
+02:56:43,200 --> 02:56:47,760
+there are many options but that's one
+
+4890
+02:56:45,520 --> 02:56:50,319
+way of of partially solving
+
+4891
+02:56:47,760 --> 02:56:51,279
+this kind of issues of not owning the
+
+4892
+02:56:50,318 --> 02:56:55,600
+data
+
+4893
+02:56:51,279 --> 02:56:57,359
+is to extend the information
+
+4894
+02:56:55,600 --> 02:56:59,200
+so i know you have something you want to
+
+4895
+02:56:57,359 --> 02:57:02,640
+add on rashford
+
+4896
+02:56:59,200 --> 02:57:02,640
+no no that makes sense
+
+4897
+02:57:04,239 --> 02:57:08,639
+again for the collaboration on this one
+
+4898
+02:57:07,40 --> 02:57:11,279
+we can do various things so
+
+4899
+02:57:08,639 --> 02:57:13,760
+in the case of um you have a typo for
+
+4900
+02:57:11,279 --> 02:57:15,920
+example in the specifications and so on
+
+4901
+02:57:13,760 --> 02:57:17,439
+you can make proposal another thing with
+
+4902
+02:57:15,920 --> 02:57:19,920
+uh
+
+4903
+02:57:17,439 --> 02:57:21,120
+on the interface here you see that you
+
+4904
+02:57:19,920 --> 02:57:23,680
+can
+
+4905
+02:57:21,120 --> 02:57:24,880
+basically make either an edit or you see
+
+4906
+02:57:23,680 --> 02:57:28,398
+that you can make
+
+4907
+02:57:24,879 --> 02:57:28,879
+a proposed edit so what is the use case
+
+4908
+02:57:28,398 --> 02:57:30,719
+of that
+
+4909
+02:57:28,879 --> 02:57:32,398
+it's it's not like for fundamental
+
+4910
+02:57:30,719 --> 02:57:34,959
+changes but for i would say minor
+
+4911
+02:57:32,398 --> 02:57:37,119
+challenges on a specific import
+
+4912
+02:57:34,959 --> 02:57:38,879
+imagine that you don't agree on this one
+
+4913
+02:57:37,120 --> 02:57:42,720
+on this idea of season
+
+4914
+02:57:38,879 --> 02:57:46,398
+there's a typo and it's not d5 but e5
+
+4915
+02:57:42,719 --> 02:57:48,639
+in the ipv6 rs so you propose the change
+
+4916
+02:57:46,398 --> 02:57:49,680
+in this case i'm playing both holes here
+
+4917
+02:57:48,639 --> 02:57:51,920
+but
+
+4918
+02:57:49,680 --> 02:57:53,120
+what do i have here it's basically an
+
+4919
+02:57:51,920 --> 02:57:55,520
+attribute
+
+4920
+02:57:53,120 --> 02:57:56,800
+with a proposal of the church and i'm
+
+4921
+02:57:55,520 --> 02:57:59,439
+playing the boss roles for the
+
+4922
+02:57:56,799 --> 02:58:02,799
+contributor roles and
+
+4923
+02:57:59,439 --> 02:58:05,760
+the original creator then i can say okay
+
+4924
+02:58:02,799 --> 02:58:07,679
+i accept the change indeed this this
+
+4925
+02:58:05,760 --> 02:58:10,960
+proposal makes sense
+
+4926
+02:58:07,680 --> 02:58:14,0
+10687.68 --> 10694
+or are basically discounted and this is
+
+4927
+02:58:10,959 --> 02:58:18,0
+10690.96 --> 10698
+a way to get updates from
+
+4928
+02:58:14,0 --> 02:58:19,439
+10694 --> 10699.439
+um from supportive other members other
+
+4929
+02:58:18,0 --> 02:58:21,40
+10698 --> 10701.04
+organizations and so on
+
+4930
+02:58:19,439 --> 02:58:22,880
+it's one way to to update the
+
+4931
+02:58:21,40 --> 02:58:26,960
+information in this case i will
+
+4932
+02:58:22,879 --> 02:58:28,879
+discuss it because it's not correct
+
+4933
+02:58:26,959 --> 02:58:30,879
+we were talking about contributions this
+
+4934
+02:58:28,879 --> 02:58:32,79
+another way of contributing is the site
+
+4935
+02:58:30,879 --> 02:58:35,679
+things itself
+
+4936
+02:58:32,79 --> 02:58:37,39
+so for example for this specifications
+
+4937
+02:58:35,680 --> 02:58:38,398
+if for example we have an expression
+
+4938
+02:58:37,40 --> 02:58:39,40
+detection system and we have seen it
+
+4939
+02:58:38,398 --> 02:58:42,719
+like
+
+4940
+02:58:39,40 --> 02:58:47,279
+three times in a row we can add
+
+4941
+02:58:42,719 --> 02:58:48,639
+on on the interface with the api
+
+4942
+02:58:47,279 --> 02:58:50,640
+through the user interface and so on
+
+4943
+02:58:48,639 --> 02:58:53,920
+that you have seen that um
+
+4944
+02:58:50,639 --> 02:58:55,920
+multiple times and like that you can
+
+4945
+02:58:53,920 --> 02:58:59,200
+share this kind of details about
+
+4946
+02:58:55,920 --> 02:59:01,200
+the sharing aspect
+
+4947
+02:58:59,200 --> 02:59:02,800
+so we what we have seen that at this
+
+4948
+02:59:01,200 --> 02:59:05,359
+specific amount of times we have
+
+4949
+02:59:02,799 --> 02:59:06,239
+the three counts saying this uh this is
+
+4950
+02:59:05,359 --> 02:59:07,920
+a site
+
+4951
+02:59:06,239 --> 02:59:09,520
+and you have seen it and you can do it
+
+4952
+02:59:07,920 --> 02:59:11,840
+per organization
+
+4953
+02:59:09,520 --> 02:59:13,439
+or it could be even anonymously you get
+
+4954
+02:59:11,840 --> 02:59:15,439
+different configuration in the model of
+
+4955
+02:59:13,439 --> 02:59:18,159
+cycling in mist
+
+4956
+02:59:15,439 --> 02:59:19,279
+but it's a way to see that an indicator
+
+4957
+02:59:18,159 --> 02:59:22,799
+has been seen
+
+4958
+02:59:19,279 --> 02:59:23,680
+or not if one specific are generating
+
+4959
+02:59:22,799 --> 02:59:25,599
+for example a
+
+4960
+02:59:23,680 --> 02:59:28,318
+false positive you can see the negative
+
+4961
+02:59:25,600 --> 02:59:30,960
+one negative sightings which
+
+4962
+02:59:28,318 --> 02:59:33,840
+basically tell others that okay this one
+
+4963
+02:59:30,959 --> 02:59:35,839
+is generating a lot of false positives
+
+4964
+02:59:33,840 --> 02:59:37,200
+sometimes not every organization agrees
+
+4965
+02:59:35,840 --> 02:59:38,719
+on the first positive because they have
+
+4966
+02:59:37,200 --> 02:59:40,800
+different views
+
+4967
+02:59:38,719 --> 02:59:42,799
+coming from different networks and so on
+
+4968
+02:59:40,799 --> 02:59:46,318
+that's a way to
+
+4969
+02:59:42,799 --> 02:59:49,358
+provide feedback so one is delegations
+
+4970
+02:59:46,318 --> 02:59:57,519
+proposals or another way is to
+
+4971
+02:59:49,359 --> 02:59:59,760
+basically get affected
+
+4972
+02:59:57,520 --> 02:59:59,760
+okay
+
+4973
+03:00:01,439 --> 03:00:04,479
+i'm just trying to go through the
+
+4974
+03:00:02,719 --> 03:00:07,278
+questions yeah
+
+4975
+03:00:04,478 --> 03:00:08,478
+maybe yes maybe there are some yeah
+
+4976
+03:00:07,279 --> 03:00:10,560
+there are some that are repeating so
+
+4977
+03:00:08,478 --> 03:00:12,799
+perhaps it's good to call them out
+
+4978
+03:00:10,559 --> 03:00:13,680
+uh so there was a bit of confusion about
+
+4979
+03:00:12,799 --> 03:00:16,0
+10812.8 --> 10816
+how to add the
+
+4980
+03:00:13,680 --> 03:00:17,40
+uh the email object so it uh checked it
+
+4981
+03:00:16,0 --> 03:00:19,200
+10816 --> 10819.2
+is a little bit
+
+4982
+03:00:17,40 --> 03:00:20,880
+uh confusing so when you're in an event
+
+4983
+03:00:19,200 --> 03:00:22,960
+and you click on add objects first you
+
+4984
+03:00:20,879 --> 03:00:24,559
+need to select the scope
+
+4985
+03:00:22,959 --> 03:00:26,478
+from which you choose from so it's going
+
+4986
+03:00:24,559 --> 03:00:28,559
+to be climate file and so on just click
+
+4987
+03:00:26,478 --> 03:00:30,159
+on all objects if you're unsure
+
+4988
+03:00:28,559 --> 03:00:31,680
+and then you can search for whatever so
+
+4989
+03:00:30,159 --> 03:00:32,398
+after you click on all objects and you
+
+4990
+03:00:31,680 --> 03:00:35,920
+type email
+
+4991
+03:00:32,398 --> 03:00:38,0
+10832.399 --> 10838
+it's going to show your email object
+
+4992
+03:00:35,920 --> 03:00:39,520
+here the first step is more like finding
+
+4993
+03:00:38,0 --> 03:00:41,680
+10838 --> 10841.68
+out the category of an object
+
+4994
+03:00:39,520 --> 03:00:43,200
+yeah so so some sometimes you just know
+
+4995
+03:00:41,680 --> 03:00:44,880
+the category but you don't know what is
+
+4996
+03:00:43,200 --> 03:00:46,800
+really available there for you
+
+4997
+03:00:44,879 --> 03:00:48,719
+so you you want to see okay what sort of
+
+4998
+03:00:46,799 --> 03:00:50,398
+objects can i use in network contacts
+
+4999
+03:00:48,719 --> 03:00:52,799
+and i would click on network first
+
+5000
+03:00:50,398 --> 03:00:54,159
+and then you get a list of of all
+
+5001
+03:00:52,799 --> 03:00:55,438
+tangently related
+
+5002
+03:00:54,159 --> 03:00:57,279
+objects that will have to do with
+
+5003
+03:00:55,439 --> 03:01:00,159
+network connectivity but
+
+5004
+03:00:57,279 --> 03:01:01,520
+not necessarily describing the same
+
+5005
+03:01:00,159 --> 03:01:04,639
+concept at all
+
+5006
+03:01:01,520 --> 03:01:06,319
+uh but if you don't know or
+
+5007
+03:01:04,639 --> 03:01:08,239
+which the domain you want to pick it
+
+5008
+03:01:06,318 --> 03:01:10,0
+10866.319 --> 10870
+from or if you know
+
+5009
+03:01:08,239 --> 03:01:11,600
+exactly already what you want and you
+
+5010
+03:01:10,0 --> 03:01:13,120
+10870 --> 10873.12
+just want to search by name just click
+
+5011
+03:01:11,600 --> 03:01:14,159
+on all objects first
+
+5012
+03:01:13,120 --> 03:01:17,680
+and then you will find what you're
+
+5013
+03:01:14,159 --> 03:01:20,879
+looking for by just typing it so email
+
+5014
+03:01:17,680 --> 03:01:25,40
+is easy to find that way
+
+5015
+03:01:20,879 --> 03:01:25,39
+okay so just type email and that's it
+
+5016
+03:01:25,359 --> 03:01:33,359
+okay um other questions
+
+5017
+03:01:28,639 --> 03:01:35,920
+that were there okay perfect
+
+5018
+03:01:33,359 --> 03:01:37,359
+and there there were a few other
+
+5019
+03:01:35,920 --> 03:01:38,398
+questions that i answered in the
+
+5020
+03:01:37,359 --> 03:01:41,40
+meanwhile maybe it's
+
+5021
+03:01:38,398 --> 03:01:42,318
+a good idea to read soft about yeah
+
+5022
+03:01:41,40 --> 03:01:44,240
+indeed there was a good one
+
+5023
+03:01:42,318 --> 03:01:45,680
+about correlation graph and and
+
+5024
+03:01:44,239 --> 03:01:47,199
+filtering on it
+
+5025
+03:01:45,680 --> 03:01:49,40
+indeed we don't have a way to filter the
+
+5026
+03:01:47,200 --> 03:01:50,479
+correlation graph but it's something
+
+5027
+03:01:49,40 --> 03:01:52,0
+10909.04 --> 10912
+that we that we've discussed for a while
+
+5028
+03:01:50,478 --> 03:01:52,398
+already and we want to do it at one
+
+5029
+03:01:52,0 --> 03:01:54,79
+10912 --> 10914.08
+point
+
+5030
+03:01:52,398 --> 03:01:56,0
+10912.399 --> 10916
+so that you can add some filter rules in
+
+5031
+03:01:54,79 --> 03:01:58,79
+there yes
+
+5032
+03:01:56,0 --> 03:01:59,760
+10916 --> 10919.76
+the only way to to do it here at least
+
+5033
+03:01:58,79 --> 03:02:01,39
+through the api so that means you you
+
+5034
+03:01:59,760 --> 03:02:03,840
+done the
+
+5035
+03:02:01,40 --> 03:02:04,640
+decorating one and then you have to do a
+
+5036
+03:02:03,840 --> 03:02:07,279
+filtering
+
+5037
+03:02:04,639 --> 03:02:07,920
+priority but it needs something that's
+
+5038
+03:02:07,279 --> 03:02:11,279
+uh
+
+5039
+03:02:07,920 --> 03:02:12,719
+yeah it will be to be added i don't know
+
+5040
+03:02:11,279 --> 03:02:17,40
+if you have an issue on that one
+
+5041
+03:02:12,719 --> 03:02:19,199
+um yeah i think we do yes yes
+
+5042
+03:02:17,40 --> 03:02:21,760
+so maybe you know what sometimes what we
+
+5043
+03:02:19,200 --> 03:02:21,760
+do is
+
+5044
+03:02:21,840 --> 03:02:26,159
+just just to add the one on this one um
+
+5045
+03:02:24,559 --> 03:02:27,359
+if i'm finding his back
+
+5046
+03:02:26,159 --> 03:02:29,359
+so i guess you can see what kind of
+
+5047
+03:02:27,359 --> 03:02:31,40
+issue that we have and so on
+
+5048
+03:02:29,359 --> 03:02:32,880
+a lot of the issue that we have is more
+
+5049
+03:02:31,40 --> 03:02:34,960
+like i mean
+
+5050
+03:02:32,879 --> 03:02:36,318
+around 25 percent 30 percent our basic
+
+5051
+03:02:34,959 --> 03:02:38,719
+installation problem
+
+5052
+03:02:36,318 --> 03:02:39,920
+um that's something that you can discuss
+
+5053
+03:02:38,719 --> 03:02:42,559
+maybe tomorrow about
+
+5054
+03:02:39,920 --> 03:02:43,359
+about recommendation on on on the
+
+5055
+03:02:42,559 --> 03:02:45,199
+systems
+
+5056
+03:02:43,359 --> 03:02:46,559
+we don't need a lot of requirements but
+
+5057
+03:02:45,200 --> 03:02:48,240
+at least um
+
+5058
+03:02:46,559 --> 03:02:49,760
+you need to have a lamp system working
+
+5059
+03:02:48,239 --> 03:02:52,879
+for mariadb
+
+5060
+03:02:49,760 --> 03:02:56,318
+linux systems and ready running
+
+5061
+03:02:52,879 --> 03:02:57,759
+so obviously for example an ubuntu
+
+5062
+03:02:56,318 --> 03:02:59,439
+distribution out of the box is working
+
+5063
+03:02:57,760 --> 03:03:02,79
+without any problems
+
+5064
+03:02:59,439 --> 03:03:02,800
+now if you try to install a missponder
+
+5065
+03:03:02,79 --> 03:03:05,359
+mac os
+
+5066
+03:03:02,799 --> 03:03:05,920
+you might turn into troubles obviously
+
+5067
+03:03:05,359 --> 03:03:07,920
+but
+
+5068
+03:03:05,920 --> 03:03:09,840
+what we recommend is we have install
+
+5069
+03:03:07,920 --> 03:03:12,159
+automatic install script for
+
+5070
+03:03:09,840 --> 03:03:14,239
+for ubuntu for example and this one
+
+5071
+03:03:12,159 --> 03:03:18,239
+works works quite well
+
+5072
+03:03:14,239 --> 03:03:18,239
+i wanted to search the issue for
+
+5073
+03:03:18,398 --> 03:03:22,559
+you just search your correlation for
+
+5074
+03:03:20,79 --> 03:03:25,840
+correlation yeah
+
+5075
+03:03:22,559 --> 03:03:26,239
+creation filtering now that will be a
+
+5076
+03:03:25,840 --> 03:03:29,279
+bit
+
+5077
+03:03:26,239 --> 03:03:31,439
+too specific i think no really not
+
+5078
+03:03:29,279 --> 03:03:40,640
+maybe yes we're filtering by correlation
+
+5079
+03:03:31,439 --> 03:03:43,520
+on feedback
+
+5080
+03:03:40,639 --> 03:03:43,519
+yeah that's easy
+
+5081
+03:03:44,719 --> 03:03:55,840
+oh this one maybe yes yeah yeah okay
+
+5082
+03:03:47,840 --> 03:03:55,840
+this one okay so
+
+5083
+03:04:03,200 --> 03:04:06,960
+so that's how we work so if you see a
+
+5084
+03:04:05,200 --> 03:04:08,560
+component issue that
+
+5085
+03:04:06,959 --> 03:04:10,239
+or a feature that is really interesting
+
+5086
+03:04:08,559 --> 03:04:11,359
+for you don't hesitate to take an
+
+5087
+03:04:10,239 --> 03:04:13,600
+existing issue
+
+5088
+03:04:11,359 --> 03:04:14,479
+about specific requests and add some
+
+5089
+03:04:13,600 --> 03:04:16,318
+comments there
+
+5090
+03:04:14,478 --> 03:04:18,0
+11054.479 --> 11058
+like for example it's really the issue
+
+5091
+03:04:16,318 --> 03:04:20,159
+the feature that you want
+
+5092
+03:04:18,0 --> 03:04:22,79
+11058 --> 11062.08
+uh is it important for you why and so on
+
+5093
+03:04:20,159 --> 03:04:25,200
+and then we use that as a source of
+
+5094
+03:04:22,79 --> 03:04:26,959
+of doing a pd request as an example we
+
+5095
+03:04:25,200 --> 03:04:29,40
+do
+
+5096
+03:04:26,959 --> 03:04:30,559
+a release of miss every three weeks
+
+5097
+03:04:29,40 --> 03:04:34,560
+usually
+
+5098
+03:04:30,559 --> 03:04:35,359
+and there are many new features on each
+
+5099
+03:04:34,559 --> 03:04:38,398
+release
+
+5100
+03:04:35,359 --> 03:04:40,318
+as an example we had a request like that
+
+5101
+03:04:38,398 --> 03:04:43,599
+sami just fixed uh
+
+5102
+03:04:40,318 --> 03:04:44,559
+two days ago about the events oh we
+
+5103
+03:04:43,600 --> 03:04:48,640
+didn't even show it
+
+5104
+03:04:44,559 --> 03:04:50,398
+even timeline and then
+
+5105
+03:04:48,639 --> 03:04:52,159
+we wanted to have something that is easy
+
+5106
+03:04:50,398 --> 03:04:52,478
+to set the number of days and then he
+
+5107
+03:04:52,159 --> 03:04:54,719
+has
+
+5108
+03:04:52,478 --> 03:04:56,318
+the new feature so sometimes it makes a
+
+5109
+03:04:54,719 --> 03:04:57,39
+lot of sense so don't hesitate to create
+
+5110
+03:04:56,318 --> 03:05:00,79
+a
+
+5111
+03:04:57,40 --> 03:05:01,359
+an issue and and propose a new new
+
+5112
+03:05:00,79 --> 03:05:05,600
+feature
+
+5113
+03:05:01,359 --> 03:05:08,79
+which remind me of showing you the even
+
+5114
+03:05:05,600 --> 03:05:09,520
+timeline because we didn't really show
+
+5115
+03:05:08,79 --> 03:05:13,359
+it
+
+5116
+03:05:09,520 --> 03:05:17,840
+so you see that on on this one
+
+5117
+03:05:13,359 --> 03:05:20,239
+we we have nearly everything
+
+5118
+03:05:17,840 --> 03:05:21,120
+same time which is basically the time
+
+5119
+03:05:20,239 --> 03:05:24,79
+when we
+
+5120
+03:05:21,120 --> 03:05:27,760
+create a different object we just set
+
+5121
+03:05:24,79 --> 03:05:31,439
+the time for four for one
+
+5122
+03:05:27,760 --> 03:05:33,120
+so and then i can
+
+5123
+03:05:31,439 --> 03:05:35,120
+basically look at this one and this one
+
+5124
+03:05:33,120 --> 03:05:37,760
+is like the
+
+5125
+03:05:35,120 --> 03:05:40,319
+yeah i don't know why we don't have the
+
+5126
+03:05:37,760 --> 03:05:41,600
+expansion on that one
+
+5127
+03:05:40,318 --> 03:05:43,359
+so for you for example if you have a
+
+5128
+03:05:41,600 --> 03:05:44,960
+specific time we can
+
+5129
+03:05:43,359 --> 03:05:46,318
+expand it and even change it in the
+
+5130
+03:05:44,959 --> 03:05:47,679
+graph so that means if we have for
+
+5131
+03:05:46,318 --> 03:05:50,559
+example this email
+
+5132
+03:05:47,680 --> 03:05:51,120
+a thing with that we can we can expand
+
+5133
+03:05:50,559 --> 03:05:54,0
+11150.56 --> 11154
+it
+
+5134
+03:05:51,120 --> 03:05:56,240
+and change when when this has been seen
+
+5135
+03:05:54,0 --> 03:05:58,559
+11154 --> 11158.56
+and we can even uh
+
+5136
+03:05:56,239 --> 03:06:00,239
+change at which time this specific
+
+5137
+03:05:58,559 --> 03:06:04,79
+specifically
+
+5138
+03:06:00,239 --> 03:06:07,439
+but that's again a good point to do
+
+5139
+03:06:04,79 --> 03:06:10,959
+is to automatically create
+
+5140
+03:06:07,439 --> 03:06:13,200
+a first thing last scene on your element
+
+5141
+03:06:10,959 --> 03:06:14,959
+because every time you do that you will
+
+5142
+03:06:13,200 --> 03:06:16,880
+get an automatic timeline
+
+5143
+03:06:14,959 --> 03:06:20,478
+and actually a quick i would say quick
+
+5144
+03:06:16,879 --> 03:06:20,478
+win when you do analysis
+
+5145
+03:06:21,510 --> 03:06:25,439
+[Music]
+
+5146
+03:06:23,760 --> 03:06:27,120
+so if there are no more questions about
+
+5147
+03:06:25,439 --> 03:06:28,800
+event creation perhaps one of the things
+
+5148
+03:06:27,120 --> 03:06:33,200
+we can do is show the searching
+
+5149
+03:06:28,799 --> 03:06:33,199
+how to search for stuff in your risk
+
+5150
+03:06:36,398 --> 03:06:40,239
+okay so this is something that we're
+
+5151
+03:06:38,799 --> 03:06:42,398
+going to show very briefly now and we're
+
+5152
+03:06:40,239 --> 03:06:43,199
+going to go a bit more detail into this
+
+5153
+03:06:42,398 --> 03:06:44,959
+tomorrow
+
+5154
+03:06:43,200 --> 03:06:47,40
+when we're also going to look at the api
+
+5155
+03:06:44,959 --> 03:06:47,679
+but generally whenever you're searching
+
+5156
+03:06:47,40 --> 03:06:49,40
+in miss
+
+5157
+03:06:47,680 --> 03:06:50,800
+the main question you need to ask
+
+5158
+03:06:49,40 --> 03:06:52,960
+yourself is
+
+5159
+03:06:50,799 --> 03:06:54,719
+what scope am i searching on am i
+
+5160
+03:06:52,959 --> 03:06:56,879
+searching for individual attributes
+
+5161
+03:06:54,719 --> 03:06:58,559
+or am i searching for events the search
+
+5162
+03:06:56,879 --> 03:07:01,278
+filters very often overlapping
+
+5163
+03:06:58,559 --> 03:07:02,318
+or aren't necessarily almost the same
+
+5164
+03:07:01,279 --> 03:07:04,79
+but one of the things you need to keep
+
+5165
+03:07:02,318 --> 03:07:04,398
+in mind is for example if i'm searching
+
+5166
+03:07:04,79 --> 03:07:06,879
+for
+
+5167
+03:07:04,398 --> 03:07:09,39
+bitcoin addresses in my miss vincent's
+
+5168
+03:07:06,879 --> 03:07:11,278
+bitcoin wallets
+
+5169
+03:07:09,40 --> 03:07:12,640
+am i searching for any event that
+
+5170
+03:07:11,279 --> 03:07:16,0
+11231.279 --> 11236
+contains at least one
+
+5171
+03:07:12,639 --> 03:07:18,239
+bitcoin address or am i searching for
+
+5172
+03:07:16,0 --> 03:07:19,920
+11236 --> 11239.92
+just the bitcoin addresses themselves
+
+5173
+03:07:18,239 --> 03:07:21,439
+so this is when we decide between
+
+5174
+03:07:19,920 --> 03:07:23,520
+different scopes so
+
+5175
+03:07:21,439 --> 03:07:25,200
+generally attribute scope will only give
+
+5176
+03:07:23,520 --> 03:07:26,399
+you the individual attributes that match
+
+5177
+03:07:25,200 --> 03:07:27,840
+the criteria
+
+5178
+03:07:26,398 --> 03:07:29,439
+and the event scope will give you
+
+5179
+03:07:27,840 --> 03:07:32,239
+everything that contains
+
+5180
+03:07:29,439 --> 03:07:34,318
+at least one matching value so here what
+
+5181
+03:07:32,239 --> 03:07:36,639
+what alex did he just searched
+
+5182
+03:07:34,318 --> 03:07:37,760
+using the attribute search for all the
+
+5183
+03:07:36,639 --> 03:07:39,519
+bitcoin addresses
+
+5184
+03:07:37,760 --> 03:07:40,880
+in the air in the instance and we see we
+
+5185
+03:07:39,520 --> 03:07:42,560
+get a bunch of them from different
+
+5186
+03:07:40,879 --> 03:07:44,559
+sources we see which events there
+
+5187
+03:07:42,559 --> 03:07:46,239
+they're from which organization has
+
+5188
+03:07:44,559 --> 03:07:47,439
+created that information and so on and
+
+5189
+03:07:46,239 --> 03:07:49,199
+so forth
+
+5190
+03:07:47,439 --> 03:07:51,520
+uh if we're happy with the search
+
+5191
+03:07:49,200 --> 03:07:53,600
+results and we've set up all our
+
+5192
+03:07:51,520 --> 03:07:55,120
+features and we're getting exactly what
+
+5193
+03:07:53,600 --> 03:07:57,279
+we were looking for
+
+5194
+03:07:55,120 --> 03:07:59,120
+maybe even several pages of it like here
+
+5195
+03:07:57,279 --> 03:08:01,200
+we can download the results in any of
+
+5196
+03:07:59,120 --> 03:08:02,640
+these supported formats so we could say
+
+5197
+03:08:01,200 --> 03:08:04,560
+okay now we have all these bitcoin
+
+5198
+03:08:02,639 --> 03:08:05,278
+addresses out there generate the csv out
+
+5199
+03:08:04,559 --> 03:08:08,398
+of it
+
+5200
+03:08:05,279 --> 03:08:10,640
+and it will generate a massive csv
+
+5201
+03:08:08,398 --> 03:08:13,199
+with all the attribute information for
+
+5202
+03:08:10,639 --> 03:08:13,199
+each of these
+
+5203
+03:08:13,840 --> 03:08:18,559
+i hope you're not running my timings
+
+5204
+03:08:15,760 --> 03:08:18,559
+inside of memory
+
+5205
+03:08:19,520 --> 03:08:23,120
+there it is
+
+5206
+03:08:21,760 --> 03:08:26,159
+[Music]
+
+5207
+03:08:23,120 --> 03:08:28,0
+11303.12 --> 11308
+so if you open it just to see the
+
+5208
+03:08:26,159 --> 03:08:31,279
+results quickly
+
+5209
+03:08:28,0 --> 03:08:34,159
+11308 --> 11314.16
+there we go so in this case uh
+
+5210
+03:08:31,279 --> 03:08:34,960
+we now downloaded our search results as
+
+5211
+03:08:34,159 --> 03:08:36,559
+csv
+
+5212
+03:08:34,959 --> 03:08:39,119
+now keep in mind whenever you're dealing
+
+5213
+03:08:36,559 --> 03:08:39,439
+with integration of mis with other tools
+
+5214
+03:08:39,120 --> 03:08:41,439
+or
+
+5215
+03:08:39,439 --> 03:08:43,680
+exports keep in mind that certain
+
+5216
+03:08:41,439 --> 03:08:45,200
+formats don't really cater to exporting
+
+5217
+03:08:43,680 --> 03:08:47,600
+certain types of data so
+
+5218
+03:08:45,200 --> 03:08:49,439
+if you're searching for ransomware
+
+5219
+03:08:47,600 --> 03:08:51,920
+payout
+
+5220
+03:08:49,439 --> 03:08:52,800
+wallets you could for example specify as
+
+5221
+03:08:51,920 --> 03:08:55,120
+a tag
+
+5222
+03:08:52,799 --> 03:08:56,398
+all the different ransomware related
+
+5223
+03:08:55,120 --> 03:08:58,880
+tags that you have
+
+5224
+03:08:56,398 --> 03:09:00,559
+and uh as a type select btc like what
+
+5225
+03:08:58,879 --> 03:09:02,239
+alex has done here and exported
+
+5226
+03:09:00,559 --> 03:09:03,920
+information now when you're deciding
+
+5227
+03:09:02,239 --> 03:09:05,760
+what format to download in
+
+5228
+03:09:03,920 --> 03:09:07,920
+again some don't make any sense so don't
+
+5229
+03:09:05,760 --> 03:09:10,239
+download bitcoin addresses in sticks
+
+5230
+03:09:07,920 --> 03:09:11,920
+format because sticks doesn't have a
+
+5231
+03:09:10,239 --> 03:09:13,359
+way to express bitcoin addresses for
+
+5232
+03:09:11,920 --> 03:09:15,439
+example
+
+5233
+03:09:13,359 --> 03:09:17,120
+so just make sure that you also take
+
+5234
+03:09:15,439 --> 03:09:19,760
+that into consideration and exporting
+
+5235
+03:09:17,120 --> 03:09:22,160
+data so that it's not wasting
+
+5236
+03:09:19,760 --> 03:09:23,680
+uh besides that we can do the same on
+
+5237
+03:09:22,159 --> 03:09:24,559
+the event level we can also do searches
+
+5238
+03:09:23,680 --> 03:09:26,800
+on the event level
+
+5239
+03:09:24,559 --> 03:09:29,39
+if we go back to our event index we have
+
+5240
+03:09:26,799 --> 03:09:29,358
+a little magnifying glass icon where you
+
+5241
+03:09:29,40 --> 03:09:31,600
+can
+
+5242
+03:09:29,359 --> 03:09:32,479
+add additional filter options to the
+
+5243
+03:09:31,600 --> 03:09:34,720
+index
+
+5244
+03:09:32,478 --> 03:09:35,519
+and filter the database on that so let's
+
+5245
+03:09:34,719 --> 03:09:38,159
+just do
+
+5246
+03:09:35,520 --> 03:09:39,520
+simple we're going to just filter on
+
+5247
+03:09:38,159 --> 03:09:41,200
+events coming from circle
+
+5248
+03:09:39,520 --> 03:09:42,960
+and we can also add for example events
+
+5249
+03:09:41,200 --> 03:09:45,439
+that are not published
+
+5250
+03:09:42,959 --> 03:09:47,358
+if you wanted to do some final checks on
+
+5251
+03:09:45,439 --> 03:09:50,960
+whether
+
+5252
+03:09:47,359 --> 03:09:52,399
+uh we need to add the organization again
+
+5253
+03:09:50,959 --> 03:09:54,79
+whether we have any events that need to
+
+5254
+03:09:52,398 --> 03:09:55,840
+be vetted for example for our own
+
+5255
+03:09:54,79 --> 03:09:57,39
+organization then we could use this
+
+5256
+03:09:55,840 --> 03:09:58,799
+filter for it
+
+5257
+03:09:57,40 --> 03:10:00,479
+on the event index all of these search
+
+5258
+03:09:58,799 --> 03:10:02,559
+filters that you apply
+
+5259
+03:10:00,478 --> 03:10:03,519
+generate a specific url and you can
+
+5260
+03:10:02,559 --> 03:10:05,359
+bookmark it
+
+5261
+03:10:03,520 --> 03:10:06,560
+so if you have recurring queries that
+
+5262
+03:10:05,359 --> 03:10:08,399
+you want to monitor
+
+5263
+03:10:06,559 --> 03:10:09,680
+then you can just bookmark the url and
+
+5264
+03:10:08,398 --> 03:10:11,358
+you can go back to it
+
+5265
+03:10:09,680 --> 03:10:12,960
+later on and see if there is anything
+
+5266
+03:10:11,359 --> 03:10:16,880
+that popped up that matches your
+
+5267
+03:10:12,959 --> 03:10:19,839
+search criteria now generally
+
+5268
+03:10:16,879 --> 03:10:21,199
+like i think 90 of our searches do not
+
+5269
+03:10:19,840 --> 03:10:23,600
+actually happen via the ui
+
+5270
+03:10:21,200 --> 03:10:25,200
+they happen via the api so very often
+
+5271
+03:10:23,600 --> 03:10:26,79
+you have tools that you search through
+
+5272
+03:10:25,200 --> 03:10:28,479
+so if you have a
+
+5273
+03:10:26,79 --> 03:10:30,238
+tool that acts as a front-end for your
+
+5274
+03:10:28,478 --> 03:10:32,0
+11428.479 --> 11432
+miss for certain searches that works as
+
+5275
+03:10:30,238 --> 03:10:33,439
+well
+
+5276
+03:10:32,0 --> 03:10:34,959
+11432 --> 11434.96
+we're going to talk more about those
+
+5277
+03:10:33,439 --> 03:10:37,120
+type of searches and how you integrate
+
+5278
+03:10:34,959 --> 03:10:39,599
+with other tools tomorrow more
+
+5279
+03:10:37,120 --> 03:10:41,279
+when we go into the api a bit is a
+
+5280
+03:10:39,600 --> 03:10:42,960
+question about soft delete attribute
+
+5281
+03:10:41,279 --> 03:10:45,600
+search
+
+5282
+03:10:42,959 --> 03:10:47,199
+i just lost the q and a so some martin
+
+5283
+03:10:45,600 --> 03:10:48,559
+asks is there a way to do a global
+
+5284
+03:10:47,200 --> 03:10:51,840
+search for software
+
+5285
+03:10:48,559 --> 03:10:54,318
+attributes yes sorry where is it
+
+5286
+03:10:51,840 --> 03:10:56,478
+there for software attachments yes there
+
+5287
+03:10:54,318 --> 03:10:59,359
+is
+
+5288
+03:10:56,478 --> 03:11:00,879
+uh so not via the ui but via the api uh
+
+5289
+03:10:59,359 --> 03:11:02,238
+which you can also access
+
+5290
+03:11:00,879 --> 03:11:03,759
+by the way we have two we have a
+
+5291
+03:11:02,238 --> 03:11:04,799
+built-in tool we can even show it show
+
+5292
+03:11:03,760 --> 03:11:08,639
+this example there
+
+5293
+03:11:04,799 --> 03:11:08,639
+we didn't show the delete i
+
+5294
+03:11:10,639 --> 03:11:15,39
+and let's start with the question first
+
+5295
+03:11:12,639 --> 03:11:16,639
+and then we go to the delete
+
+5296
+03:11:15,40 --> 03:11:18,560
+so we have this built-in tool called the
+
+5297
+03:11:16,639 --> 03:11:22,478
+rest client that allows us to run
+
+5298
+03:11:18,559 --> 03:11:24,318
+searches directly from the interface so
+
+5299
+03:11:22,478 --> 03:11:26,0
+11482.479 --> 11486
+generally indeed we have a software
+
+5300
+03:11:24,318 --> 03:11:29,119
+delete mechanism in bisp
+
+5301
+03:11:26,0 --> 03:11:30,79
+11486 --> 11490.08
+that allows you to to not fully remove
+
+5302
+03:11:29,120 --> 03:11:32,239
+an attribute but
+
+5303
+03:11:30,79 --> 03:11:33,920
+mark is for it for deletion the reason
+
+5304
+03:11:32,238 --> 03:11:36,159
+why we do this in general is
+
+5305
+03:11:33,920 --> 03:11:37,439
+whenever we're synchronizing information
+
+5306
+03:11:36,159 --> 03:11:38,799
+and we delete an attribute
+
+5307
+03:11:37,439 --> 03:11:40,880
+we want to inform all the leather
+
+5308
+03:11:38,799 --> 03:11:42,159
+instances attribute needs to be removed
+
+5309
+03:11:40,879 --> 03:11:44,238
+it is revoked
+
+5310
+03:11:42,159 --> 03:11:45,680
+so this is why we do the soft delete
+
+5311
+03:11:44,238 --> 03:11:48,478
+when we hide it from the interface
+
+5312
+03:11:45,680 --> 03:11:50,639
+behind it from the exports
+
+5313
+03:11:48,478 --> 03:11:52,0
+11508.479 --> 11512
+but we still keep the data and we inform
+
+5314
+03:11:50,639 --> 03:11:54,0
+11510.64 --> 11514
+the other instances that they need to
+
+5315
+03:11:52,0 --> 03:11:57,120
+11512 --> 11517.12
+also market for deletion
+
+5316
+03:11:54,0 --> 03:11:58,799
+11514 --> 11518.8
+now if the question is how do we do a
+
+5317
+03:11:57,120 --> 03:12:00,319
+global search for all the soft deleted
+
+5318
+03:11:58,799 --> 03:12:00,799
+attributes so first of all what we need
+
+5319
+03:12:00,318 --> 03:12:04,478
+to do
+
+5320
+03:12:00,799 --> 03:12:06,799
+yeah using our little research too
+
+5321
+03:12:04,478 --> 03:12:08,719
+is by the way we have the modern apis
+
+5322
+03:12:06,799 --> 03:12:11,438
+here to create a new api unless you know
+
+5323
+03:12:08,719 --> 03:12:11,438
+yours by heart
+
+5324
+03:12:12,0 --> 03:12:17,200
+11532 --> 11537.2
+so alex because you it's very good
+
+5325
+03:12:17,359 --> 03:12:20,479
+so so just quickly that's so uh so in
+
+5326
+03:12:19,439 --> 03:12:22,318
+the meanwhile what
+
+5327
+03:12:20,478 --> 03:12:24,238
+alex is doing now is uh he's going to
+
+5328
+03:12:22,318 --> 03:12:26,959
+generate a new api key for himself
+
+5329
+03:12:24,238 --> 03:12:29,359
+so that we can actually test the api uh
+
+5330
+03:12:26,959 --> 03:12:33,839
+queries
+
+5331
+03:12:29,359 --> 03:12:33,840
+oh that's one word yeah
+
+5332
+03:12:35,279 --> 03:12:47,840
+yeah you can add enough key from here as
+
+5333
+03:12:36,719 --> 03:12:47,840
+well this will work yeah that works
+
+5334
+03:12:54,129 --> 03:12:57,279
+[Music]
+
+5335
+03:12:59,680 --> 03:13:16,238
+a global action my profile by the way if
+
+5336
+03:13:01,520 --> 03:13:16,238
+you want to find your profile okay
+
+5337
+03:13:17,359 --> 03:13:21,760
+so now we have our api key now we go to
+
+5338
+03:13:20,159 --> 03:13:22,398
+rest client we just paste it in there
+
+5339
+03:13:21,760 --> 03:13:25,680
+now
+
+5340
+03:13:22,398 --> 03:13:25,680
+in the authorization field
+
+5341
+03:13:27,439 --> 03:13:30,639
+here we go and now what we're going to
+
+5342
+03:13:28,799 --> 03:13:32,79
+do is we're going to uh to run a search
+
+5343
+03:13:30,639 --> 03:13:32,478
+for all software attributes so we're
+
+5344
+03:13:32,79 --> 03:13:35,680
+going to
+
+5345
+03:13:32,478 --> 03:13:37,519
+search for attribute rest search so that
+
+5346
+03:13:35,680 --> 03:13:38,960
+is a scope that allows us to search on
+
+5347
+03:13:37,520 --> 03:13:41,120
+the attribute level we'll do we'll see
+
+5348
+03:13:38,959 --> 03:13:44,0
+11618.96 --> 11624
+more of this tomorrow
+
+5349
+03:13:41,120 --> 03:13:47,600
+just a small example for return format
+
+5350
+03:13:44,0 --> 03:13:47,600
+11624 --> 11627.6
+let's pick something like json
+
+5351
+03:13:53,520 --> 03:13:59,520
+and perhaps set a page under limit or
+
+5352
+03:13:56,719 --> 03:14:01,119
+date one limit 100 or something like
+
+5353
+03:13:59,520 --> 03:14:02,479
+that
+
+5354
+03:14:01,120 --> 03:14:04,640
+i don't know how much was deleted here
+
+5355
+03:14:02,478 --> 03:14:07,199
+but it might be a lot and uh
+
+5356
+03:14:04,639 --> 03:14:11,840
+then just uh add another key deleted
+
+5357
+03:14:07,200 --> 03:14:11,840
+there we go
+
+5358
+03:14:12,159 --> 03:14:15,439
+and then deleted september
+
+5359
+03:14:16,398 --> 03:14:19,680
+and we don't need anything else
+
+5360
+03:14:20,318 --> 03:14:24,478
+and this will return the first 100 hits
+
+5361
+03:14:23,279 --> 03:14:28,238
+from the instance
+
+5362
+03:14:24,478 --> 03:14:28,238
+of attributes that are deleted
+
+5363
+03:14:30,398 --> 03:14:35,278
+there we go and now if you if you wanted
+
+5364
+03:14:33,600 --> 03:14:36,720
+to paginate through all these attributes
+
+5365
+03:14:35,279 --> 03:14:37,359
+you would have to just raise the page
+
+5366
+03:14:36,719 --> 03:14:40,0
+11676.72 --> 11680
+number
+
+5367
+03:14:37,359 --> 03:14:40,800
+go back and and get page 2 page 3 page 4
+
+5368
+03:14:40,0 --> 03:14:42,799
+11680 --> 11682.8
+and so on
+
+5369
+03:14:40,799 --> 03:14:44,959
+or if we have enough memory certainly my
+
+5370
+03:14:42,799 --> 03:14:46,318
+training instance definitely doesn't
+
+5371
+03:14:44,959 --> 03:14:49,278
+then we could just say give us
+
+5372
+03:14:46,318 --> 03:14:49,278
+everything in one shot
+
+5373
+03:14:49,600 --> 03:14:53,840
+okay so i hope that answers your
+
+5374
+03:14:52,79 --> 03:14:56,559
+question martin
+
+5375
+03:14:53,840 --> 03:14:58,559
+um there is also a question is there an
+
+5376
+03:14:56,559 --> 03:15:01,600
+official miss docker image
+
+5377
+03:14:58,559 --> 03:15:04,318
+um and there are actually several uh
+
+5378
+03:15:01,600 --> 03:15:05,439
+they're not maintained by us but by
+
+5379
+03:15:04,318 --> 03:15:08,0
+11704.319 --> 11708
+contributors
+
+5380
+03:15:05,439 --> 03:15:09,200
+that are very active and working closely
+
+5381
+03:15:08,0 --> 03:15:11,680
+11708 --> 11711.68
+with us
+
+5382
+03:15:09,200 --> 03:15:13,279
+so i've pasted one example in the zoom
+
+5383
+03:15:11,680 --> 03:15:14,960
+group chat
+
+5384
+03:15:13,279 --> 03:15:16,560
+i don't know if maybe it's not visible
+
+5385
+03:15:14,959 --> 03:15:19,119
+to everyone
+
+5386
+03:15:16,559 --> 03:15:20,719
+i can just drop it as an answer here
+
+5387
+03:15:19,120 --> 03:15:24,160
+yeah it's better
+
+5388
+03:15:20,719 --> 03:15:26,79
+so this one is done by cool acid so why
+
+5389
+03:15:24,159 --> 03:15:29,600
+there are so many docker myths
+
+5390
+03:15:26,79 --> 03:15:32,398
+that's i think the the
+
+5391
+03:15:29,600 --> 03:15:35,200
+speciality of docker not everyone agrees
+
+5392
+03:15:32,398 --> 03:15:37,760
+on a model with docker so there are
+
+5393
+03:15:35,200 --> 03:15:39,520
+at least as far as i know four or five
+
+5394
+03:15:37,760 --> 03:15:41,760
+different dockers there's one managed by
+
+5395
+03:15:39,520 --> 03:15:45,40
+dcso one by cool assist
+
+5396
+03:15:41,760 --> 03:15:47,359
+one by xavier mcpens and one by
+
+5397
+03:15:45,40 --> 03:15:48,479
+harvard security and i'm sure i'm
+
+5398
+03:15:47,359 --> 03:15:51,520
+missing some
+
+5399
+03:15:48,478 --> 03:15:54,159
+um so the thing is um for
+
+5400
+03:15:51,520 --> 03:15:55,840
+for the docker images it's depending of
+
+5401
+03:15:54,159 --> 03:15:57,600
+i would say your test
+
+5402
+03:15:55,840 --> 03:15:59,439
+so have a look at what the different
+
+5403
+03:15:57,600 --> 03:16:02,0
+11757.6 --> 11762
+contributors are doing
+
+5404
+03:15:59,439 --> 03:16:02,800
+and you'll see that you pick the one
+
+5405
+03:16:02,0 --> 03:16:05,200
+11762 --> 11765.2
+that is
+
+5406
+03:16:02,799 --> 03:16:06,159
+matching what you really want to do with
+
+5407
+03:16:05,200 --> 03:16:08,720
+docker
+
+5408
+03:16:06,159 --> 03:16:09,359
+some are really more separated container
+
+5409
+03:16:08,719 --> 03:16:11,199
+wise
+
+5410
+03:16:09,359 --> 03:16:12,800
+some are more like one single container
+
+5411
+03:16:11,200 --> 03:16:14,399
+with everything um
+
+5412
+03:16:12,799 --> 03:16:16,79
+again it's a maker of taste and all you
+
+5413
+03:16:14,398 --> 03:16:18,398
+want to to operate one
+
+5414
+03:16:16,79 --> 03:16:19,359
+we don't maintain one as this project
+
+5415
+03:16:18,398 --> 03:16:21,519
+but there are
+
+5416
+03:16:19,359 --> 03:16:24,399
+some that are under our missed project
+
+5417
+03:16:21,520 --> 03:16:24,399
+guitar position
+
+5418
+03:16:27,200 --> 03:16:33,120
+someone is asking about api key to
+
+5419
+03:16:29,920 --> 03:16:33,120
+invoke cortex analyzer
+
+5420
+03:16:33,520 --> 03:16:37,40
+for the cortex analyzer it's a separate
+
+5421
+03:16:36,398 --> 03:16:40,398
+tool set
+
+5422
+03:16:37,40 --> 03:16:44,319
+of part of of the i've project
+
+5423
+03:16:40,398 --> 03:16:46,799
+and then you have specific api keys
+
+5424
+03:16:44,318 --> 03:16:48,879
+cortex extension is like this module so
+
+5425
+03:16:46,799 --> 03:16:51,39
+it works for the expansion services
+
+5426
+03:16:48,879 --> 03:16:52,238
+uh beaker full cortex analyzer are not
+
+5427
+03:16:51,40 --> 03:16:53,840
+supporting
+
+5428
+03:16:52,238 --> 03:16:55,600
+objects and stuff like that which is the
+
+5429
+03:16:53,840 --> 03:16:57,600
+case for its modules
+
+5430
+03:16:55,600 --> 03:16:59,120
+so you might have expansion on the
+
+5431
+03:16:57,600 --> 03:17:01,120
+interface but if you want full-blown
+
+5432
+03:16:59,120 --> 03:17:03,520
+expansion with relationship and so on
+
+5433
+03:17:01,120 --> 03:17:05,359
+then you can use these modules a lot of
+
+5434
+03:17:03,520 --> 03:17:06,800
+organizations are mixing both so you can
+
+5435
+03:17:05,359 --> 03:17:09,359
+have cortex-enabled and
+
+5436
+03:17:06,799 --> 03:17:10,238
+it's modulus enabled on the same missed
+
+5437
+03:17:09,359 --> 03:17:11,680
+instance
+
+5438
+03:17:10,238 --> 03:17:13,920
+but going back to the question if you
+
+5439
+03:17:11,680 --> 03:17:16,159
+already have the cortex api encoded in
+
+5440
+03:17:13,920 --> 03:17:18,960
+your misspen you want to invoke
+
+5441
+03:17:16,159 --> 03:17:20,959
+a lookup uh through the api through misp
+
+5442
+03:17:18,959 --> 03:17:22,238
+then you can use your misspik to tell
+
+5443
+03:17:20,959 --> 03:17:27,438
+your misp to
+
+5444
+03:17:22,238 --> 03:17:29,520
+run a query against cortex
+
+5445
+03:17:27,439 --> 03:17:33,200
+but with the new api key models usually
+
+5446
+03:17:29,520 --> 03:17:33,200
+it's better to have dedicated api
+
+5447
+03:17:35,600 --> 03:17:42,569
+okay um there is something else easy
+
+5448
+03:17:39,680 --> 03:17:44,479
+you know that we had it already um
+
+5449
+03:17:42,569 --> 03:17:46,159
+[Music]
+
+5450
+03:17:44,478 --> 03:17:48,159
+could you touch on how we could use one
+
+5451
+03:17:46,159 --> 03:17:50,639
+event to add multiple attributes and how
+
+5452
+03:17:48,159 --> 03:17:52,398
+would correlation work here uh configure
+
+5453
+03:17:50,639 --> 03:17:53,358
+event one to fetch all records from a
+
+5454
+03:17:52,398 --> 03:17:54,799
+fishing feed
+
+5455
+03:17:53,359 --> 03:17:56,800
+would this work with correlation show
+
+5456
+03:17:54,799 --> 03:17:58,719
+all instances where any of those
+
+5457
+03:17:56,799 --> 03:17:59,759
+attributes match with other events from
+
+5458
+03:17:58,719 --> 03:18:02,799
+other organization
+
+5459
+03:17:59,760 --> 03:18:03,760
+events well okay if i understand it
+
+5460
+03:18:02,799 --> 03:18:06,318
+correctly indeed
+
+5461
+03:18:03,760 --> 03:18:08,318
+so if you if you do that you create an
+
+5462
+03:18:06,318 --> 03:18:09,920
+event for a fishing feed
+
+5463
+03:18:08,318 --> 03:18:11,920
+and you have those attributes in there
+
+5464
+03:18:09,920 --> 03:18:14,879
+and you have cross you have cached
+
+5465
+03:18:11,920 --> 03:18:16,879
+other instances then within that that
+
+5466
+03:18:14,879 --> 03:18:17,519
+feeds event you will see correlations
+
+5467
+03:18:16,879 --> 03:18:19,278
+both to
+
+5468
+03:18:17,520 --> 03:18:21,359
+other events created locally on your
+
+5469
+03:18:19,279 --> 03:18:23,359
+instance by other organizations
+
+5470
+03:18:21,359 --> 03:18:24,720
+as well as links to other instances that
+
+5471
+03:18:23,359 --> 03:18:26,960
+have the
+
+5472
+03:18:24,719 --> 03:18:27,760
+data as long as you have cached those
+
+5473
+03:18:26,959 --> 03:18:29,438
+events
+
+5474
+03:18:27,760 --> 03:18:31,120
+so we're going to talk more about that
+
+5475
+03:18:29,439 --> 03:18:31,840
+tomorrow about the synchronization but
+
+5476
+03:18:31,120 --> 03:18:33,439
+when you're
+
+5477
+03:18:31,840 --> 03:18:34,880
+interconnecting with another instance
+
+5478
+03:18:33,439 --> 03:18:36,639
+you can do it in two ways
+
+5479
+03:18:34,879 --> 03:18:38,398
+one i want to start exchanging data
+
+5480
+03:18:36,639 --> 03:18:40,639
+pushing data pooling data
+
+5481
+03:18:38,398 --> 03:18:42,318
+or two i can just tell my mist to go
+
+5482
+03:18:40,639 --> 03:18:44,799
+crawl that other instance
+
+5483
+03:18:42,318 --> 03:18:46,559
+uh hash all the values that they have
+
+5484
+03:18:44,799 --> 03:18:48,559
+and if i ever get the correlation
+
+5485
+03:18:46,559 --> 03:18:50,79
+then it flags it for me that it shows me
+
+5486
+03:18:48,559 --> 03:18:52,79
+and then that the
+
+5487
+03:18:50,79 --> 03:18:54,238
+instance already knows about this value
+
+5488
+03:18:52,79 --> 03:18:55,920
+and i can pivot over to previewing the
+
+5489
+03:18:54,238 --> 03:18:58,398
+data
+
+5490
+03:18:55,920 --> 03:19:00,79
+so i hope that answers that yeah and
+
+5491
+03:18:58,398 --> 03:19:01,358
+then the correlation of
+
+5492
+03:19:00,79 --> 03:19:03,600
+for example if you just enable the
+
+5493
+03:19:01,359 --> 03:19:05,760
+caching you just see that it's
+
+5494
+03:19:03,600 --> 03:19:08,479
+correlating with specific values without
+
+5495
+03:19:05,760 --> 03:19:09,279
+providing the full fit sometimes it's
+
+5496
+03:19:08,478 --> 03:19:11,519
+it's quite
+
+5497
+03:19:09,279 --> 03:19:13,40
+handy when you have for example see that
+
+5498
+03:19:11,520 --> 03:19:15,920
+you cannot show the data but you can
+
+5499
+03:19:13,40 --> 03:19:15,920
+show the correlation
+
+5500
+03:19:16,159 --> 03:19:19,680
+there's another one do you recommend
+
+5501
+03:19:17,439 --> 03:19:22,398
+using miss palone or using the hive
+
+5502
+03:19:19,680 --> 03:19:22,800
+miss cortex integration i mean generally
+
+5503
+03:19:22,398 --> 03:19:24,478
+yeah
+
+5504
+03:19:22,799 --> 03:19:26,318
+if you need a case management tool then
+
+5505
+03:19:24,478 --> 03:19:29,920
+then using the hive for that is great
+
+5506
+03:19:26,318 --> 03:19:31,439
+and so it makes absolute sense to you to
+
+5507
+03:19:29,920 --> 03:19:33,920
+use them together
+
+5508
+03:19:31,439 --> 03:19:34,880
+and integration is really smoothly done
+
+5509
+03:19:33,920 --> 03:19:36,639
+so that means that
+
+5510
+03:19:34,879 --> 03:19:38,238
+that no matter where you start your your
+
+5511
+03:19:36,639 --> 03:19:40,398
+process whether you start
+
+5512
+03:19:38,238 --> 03:19:41,840
+by creating an event in misp or whether
+
+5513
+03:19:40,398 --> 03:19:44,79
+you start by creating a
+
+5514
+03:19:41,840 --> 03:19:46,0
+11981.84 --> 11986
+case in the hive you can basically
+
+5515
+03:19:44,79 --> 03:19:46,639
+propagate the data to the other tool and
+
+5516
+03:19:46,0 --> 03:19:49,200
+11986 --> 11989.2
+work on
+
+5517
+03:19:46,639 --> 03:19:50,79
+on both tools and data so so yeah
+
+5518
+03:19:49,200 --> 03:19:52,79
+absolutely
+
+5519
+03:19:50,79 --> 03:19:54,559
+yeah absolutely it's pretty smooth just
+
+5520
+03:19:52,79 --> 03:19:56,159
+just be careful if you use the expansion
+
+5521
+03:19:54,559 --> 03:19:58,799
+on mist and you have miss modules
+
+5522
+03:19:56,159 --> 03:20:00,318
+enabled i would prefer to have
+
+5523
+03:19:58,799 --> 03:20:03,199
+modules enabled because you you
+
+5524
+03:20:00,318 --> 03:20:06,318
+basically have all the features of mixed
+
+5525
+03:20:03,200 --> 03:20:08,159
+like relationship objects and so on
+
+5526
+03:20:06,318 --> 03:20:09,439
+with the cortex integration is basically
+
+5527
+03:20:08,159 --> 03:20:11,600
+just the over with
+
+5528
+03:20:09,439 --> 03:20:12,559
+the vortex yeah but one of the things
+
+5529
+03:20:11,600 --> 03:20:14,79
+that you can do is
+
+5530
+03:20:12,559 --> 03:20:16,0
+12012.56 --> 12016
+if you start for example from the hive
+
+5531
+03:20:14,79 --> 03:20:17,279
+perspective and you push the data
+
+5532
+03:20:16,0 --> 03:20:18,799
+12016 --> 12018.8
+afterwards to misp
+
+5533
+03:20:17,279 --> 03:20:20,640
+you can then go through this process
+
+5534
+03:20:18,799 --> 03:20:21,759
+like what we've done here with enriching
+
+5535
+03:20:20,639 --> 03:20:24,159
+the information
+
+5536
+03:20:21,760 --> 03:20:25,760
+creating objects that affect attributes
+
+5537
+03:20:24,159 --> 03:20:27,200
+so you can do it as a secondary step
+
+5538
+03:20:25,760 --> 03:20:28,0
+12025.76 --> 12028
+before you share it out to community to
+
+5539
+03:20:27,200 --> 03:20:30,79
+refine the data
+
+5540
+03:20:28,0 --> 03:20:31,920
+12028 --> 12031.92
+in mis that you've created in the i for
+
+5541
+03:20:30,79 --> 03:20:33,439
+example and the same thing if you've
+
+5542
+03:20:31,920 --> 03:20:34,719
+used cortex to fetch additional
+
+5543
+03:20:33,439 --> 03:20:36,398
+information in the hive
+
+5544
+03:20:34,719 --> 03:20:38,0
+12034.72 --> 12038
+you can then take that data and further
+
+5545
+03:20:36,398 --> 03:20:38,959
+enrich it with miss modules once it's a
+
+5546
+03:20:38,0 --> 03:20:40,959
+12038 --> 12040.96
+message
+
+5547
+03:20:38,959 --> 03:20:42,79
+yeah this is a good question from
+
+5548
+03:20:40,959 --> 03:20:45,278
+muammar
+
+5549
+03:20:42,79 --> 03:20:47,120
+junaid about when i try to import the
+
+5550
+03:20:45,279 --> 03:20:49,40
+data from six to five it's called
+
+5551
+03:20:47,120 --> 03:20:50,880
+lazy like can you please explain that a
+
+5552
+03:20:49,40 --> 03:20:52,640
+bit and this one is interesting
+
+5553
+03:20:50,879 --> 03:20:54,398
+because it's it's i was saying a long
+
+5554
+03:20:52,639 --> 03:20:57,358
+long long discussion and that
+
+5555
+03:20:54,398 --> 03:21:00,0
+12054.399 --> 12060
+that's even influence or miss people
+
+5556
+03:20:57,359 --> 03:21:03,40
+than the standard behind missed
+
+5557
+03:21:00,0 --> 03:21:04,0
+12060 --> 12064
+so sticks is really uh focusing on cyber
+
+5558
+03:21:03,40 --> 03:21:07,279
+security and
+
+5559
+03:21:04,0 --> 03:21:10,318
+12064 --> 12070.319
+cyber studies religion and
+
+5560
+03:21:07,279 --> 03:21:11,920
+the the problem is you might have at
+
+5561
+03:21:10,318 --> 03:21:13,760
+some point in time
+
+5562
+03:21:11,920 --> 03:21:15,120
+data that are basically not defined
+
+5563
+03:21:13,760 --> 03:21:17,760
+anywhere
+
+5564
+03:21:15,120 --> 03:21:20,160
+so it's more for the export of data so
+
+5565
+03:21:17,760 --> 03:21:23,40
+for example if you export in a mixed
+
+5566
+03:21:20,159 --> 03:21:23,439
+event and you have for example an object
+
+5567
+03:21:23,40 --> 03:21:25,520
+with
+
+5568
+03:21:23,439 --> 03:21:28,479
+the person and stuff like that it won't
+
+5569
+03:21:25,520 --> 03:21:31,600
+be in the sticks to export for example
+
+5570
+03:21:28,478 --> 03:21:33,519
+so it means that in misprevent you get
+
+5571
+03:21:31,600 --> 03:21:35,200
+all the information but it's bound to
+
+5572
+03:21:33,520 --> 03:21:36,238
+the limitation of the standards and the
+
+5573
+03:21:35,200 --> 03:21:37,600
+format
+
+5574
+03:21:36,238 --> 03:21:39,520
+where you export and it's exactly the
+
+5575
+03:21:37,600 --> 03:21:42,238
+same for any format i mean if you
+
+5576
+03:21:39,520 --> 03:21:43,760
+um export a person in theory cata format
+
+5577
+03:21:42,238 --> 03:21:46,799
+obviously you don't have any
+
+5578
+03:21:43,760 --> 03:21:47,600
+um field or things like that with person
+
+5579
+03:21:46,799 --> 03:21:49,438
+and so on so
+
+5580
+03:21:47,600 --> 03:21:51,439
+that's why we call it losing because uh
+
+5581
+03:21:49,439 --> 03:21:55,840
+sometimes when you import data
+
+5582
+03:21:51,439 --> 03:21:55,840
+it's bound to a specific set of
+
+5583
+03:21:55,920 --> 03:21:58,960
+fields that are supported and so on
+
+5584
+03:21:58,0 --> 03:22:01,359
+12118 --> 12121.359
+another thing that is
+
+5585
+03:21:58,959 --> 03:22:02,719
+quite important with sticks you might
+
+5586
+03:22:01,359 --> 03:22:05,279
+have a lot of
+
+5587
+03:22:02,719 --> 03:22:06,639
+peculiarities or specialities depending
+
+5588
+03:22:05,279 --> 03:22:08,479
+on the vendor
+
+5589
+03:22:06,639 --> 03:22:09,840
+some vendors are adding some some
+
+5590
+03:22:08,478 --> 03:22:11,679
+specific custom objects
+
+5591
+03:22:09,840 --> 03:22:13,359
+things like that that are not bound to
+
+5592
+03:22:11,680 --> 03:22:15,600
+any existing one
+
+5593
+03:22:13,359 --> 03:22:16,960
+so we are importing them as kind of you
+
+5594
+03:22:15,600 --> 03:22:20,238
+know generic one but
+
+5595
+03:22:16,959 --> 03:22:22,238
+it is basically like uh lucy again so
+
+5596
+03:22:20,238 --> 03:22:23,760
+you have to be careful when you you use
+
+5597
+03:22:22,238 --> 03:22:26,318
+a specific format
+
+5598
+03:22:23,760 --> 03:22:27,40
+to be sure that you properly uh map an
+
+5599
+03:22:26,318 --> 03:22:29,199
+existing
+
+5600
+03:22:27,40 --> 03:22:31,200
+different one so it's more for the
+
+5601
+03:22:29,200 --> 03:22:33,520
+export is quite flexible on that so you
+
+5602
+03:22:31,200 --> 03:22:36,239
+can basically have any object you like
+
+5603
+03:22:33,520 --> 03:22:36,880
+but when we explore for example in 61 we
+
+5604
+03:22:36,238 --> 03:22:39,840
+just
+
+5605
+03:22:36,879 --> 03:22:41,39
+support what is existing in sticks even
+
+5606
+03:22:39,840 --> 03:22:43,359
+if we start we add
+
+5607
+03:22:41,40 --> 03:22:45,840
+some some custom objects too which are
+
+5608
+03:22:43,359 --> 03:22:47,840
+on to the missed object
+
+5609
+03:22:45,840 --> 03:22:49,680
+but some tools will not recognize
+
+5610
+03:22:47,840 --> 03:22:50,79
+obviously the custom object because they
+
+5611
+03:22:49,680 --> 03:22:52,79
+are
+
+5612
+03:22:50,79 --> 03:22:53,840
+just having a profile for a specific set
+
+5613
+03:22:52,79 --> 03:22:56,398
+of known uh updates
+
+5614
+03:22:53,840 --> 03:22:56,960
+yeah i think that's exactly the point uh
+
+5615
+03:22:56,398 --> 03:22:58,238
+that
+
+5616
+03:22:56,959 --> 03:23:00,959
+maybe is different from when we
+
+5617
+03:22:58,238 --> 03:23:02,0
+12178.239 --> 12182
+described the text in those import and
+
+5618
+03:23:00,959 --> 03:23:04,159
+export fields
+
+5619
+03:23:02,0 --> 03:23:06,159
+12182 --> 12186.16
+we say lossy but in reality what we do
+
+5620
+03:23:04,159 --> 03:23:07,119
+is we do try to capture everything and
+
+5621
+03:23:06,159 --> 03:23:08,959
+we do try to map
+
+5622
+03:23:07,120 --> 03:23:10,479
+everything but a lot of it will end up
+
+5623
+03:23:08,959 --> 03:23:13,39
+in custom objects now
+
+5624
+03:23:10,478 --> 03:23:14,959
+now what alex mentioned is the problem
+
+5625
+03:23:13,40 --> 03:23:16,399
+even if we export bitcoin
+
+5626
+03:23:14,959 --> 03:23:18,238
+addresses for example whenever we're
+
+5627
+03:23:16,398 --> 03:23:20,478
+pushing in sticks to format
+
+5628
+03:23:18,238 --> 03:23:21,359
+as custom objects no other two will pick
+
+5629
+03:23:20,478 --> 03:23:23,840
+up on it because
+
+5630
+03:23:21,359 --> 03:23:25,439
+it's if we're just using custom objects
+
+5631
+03:23:23,840 --> 03:23:27,40
+that unless the other two
+
+5632
+03:23:25,439 --> 03:23:28,720
+specifically looks for them they will
+
+5633
+03:23:27,40 --> 03:23:31,120
+just either store it as is
+
+5634
+03:23:28,719 --> 03:23:32,238
+or not know what to do with it yeah and
+
+5635
+03:23:31,120 --> 03:23:35,439
+that
+
+5636
+03:23:32,238 --> 03:23:35,680
+that's why we recommend a feed provider
+
+5637
+03:23:35,439 --> 03:23:38,79
+of
+
+5638
+03:23:35,680 --> 03:23:39,40
+anderson son to actively support the
+
+5639
+03:23:38,79 --> 03:23:41,39
+misformat
+
+5640
+03:23:39,40 --> 03:23:42,840
+then they can they can really impose a
+
+5641
+03:23:41,40 --> 03:23:44,239
+full set of objects and so that already
+
+5642
+03:23:42,840 --> 03:23:46,159
+exists
+
+5643
+03:23:44,238 --> 03:23:47,760
+yeah in some cases however you don't
+
+5644
+03:23:46,159 --> 03:23:49,439
+really care about having the full set
+
+5645
+03:23:47,760 --> 03:23:50,960
+and that's where for example specialized
+
+5646
+03:23:49,439 --> 03:23:53,40
+formats are really cool
+
+5647
+03:23:50,959 --> 03:23:55,199
+so whenever we're feeding for example an
+
+5648
+03:23:53,40 --> 03:23:56,560
+ids for example we don't care about
+
+5649
+03:23:55,200 --> 03:23:59,359
+bitcoin addresses
+
+5650
+03:23:56,559 --> 03:23:59,760
+so in those cases uh so sticks and misp
+
+5651
+03:23:59,359 --> 03:24:04,79
+both
+
+5652
+03:23:59,760 --> 03:24:05,760
+are very expressive uh exchange formats
+
+5653
+03:24:04,79 --> 03:24:07,920
+but whenever you're dealing with feeding
+
+5654
+03:24:05,760 --> 03:24:10,238
+tools for example you don't care about
+
+5655
+03:24:07,920 --> 03:24:11,200
+uh about losing ninety percent even of
+
+5656
+03:24:10,238 --> 03:24:13,680
+the data set
+
+5657
+03:24:11,200 --> 03:24:15,120
+as long as you capture those type of
+
+5658
+03:24:13,680 --> 03:24:17,680
+data points that your tool can
+
+5659
+03:24:15,120 --> 03:24:19,40
+process in the end so this is why
+
+5660
+03:24:17,680 --> 03:24:20,559
+generally what we recommend is if you
+
+5661
+03:24:19,40 --> 03:24:21,200
+have the option for example to export
+
+5662
+03:24:20,559 --> 03:24:23,39
+data from
+
+5663
+03:24:21,200 --> 03:24:24,800
+is for your ideas for your scene and so
+
+5664
+03:24:23,40 --> 03:24:27,359
+on and you have the option between for
+
+5665
+03:24:24,799 --> 03:24:29,519
+example sticks or snort or surikata
+
+5666
+03:24:27,359 --> 03:24:31,279
+go with snorter sturikata because
+
+5667
+03:24:29,520 --> 03:24:33,760
+because those are much more
+
+5668
+03:24:31,279 --> 03:24:35,40
+uh catering to what your two can
+
+5669
+03:24:33,760 --> 03:24:37,200
+actually understand
+
+5670
+03:24:35,40 --> 03:24:40,80
+yeah for example for yards the same you
+
+5671
+03:24:37,200 --> 03:24:41,680
+prefer to have like a good yara who will
+
+5672
+03:24:40,79 --> 03:24:43,279
+say that you can run into another
+
+5673
+03:24:41,680 --> 03:24:44,0
+12281.68 --> 12284
+barista or your endpoint protection
+
+5674
+03:24:43,279 --> 03:24:46,159
+device
+
+5675
+03:24:44,0 --> 03:24:49,840
+12284 --> 12289.84
+and having a generic one that will not
+
+5676
+03:24:46,159 --> 03:24:49,840
+help you to lose the detection
+
+5677
+03:24:52,559 --> 03:24:55,840
+other questions
+
+5678
+03:24:56,79 --> 03:24:59,120
+you already took that one that is there
+
+5679
+03:24:58,639 --> 03:25:00,879
+it is
+
+5680
+03:24:59,120 --> 03:25:03,920
+longer i think we took most of them
+
+5681
+03:25:00,879 --> 03:25:06,238
+unless they missed one
+
+5682
+03:25:03,920 --> 03:25:08,398
+and yeah perhaps we should show the
+
+5683
+03:25:06,238 --> 03:25:09,199
+deletions because we we didn't actually
+
+5684
+03:25:08,398 --> 03:25:11,760
+show it indeed
+
+5685
+03:25:09,200 --> 03:25:11,760
+yeah exactly
+
+5686
+03:25:13,760 --> 03:25:17,40
+okay oh and now we have some more
+
+5687
+03:25:16,79 --> 03:25:20,159
+questions
+
+5688
+03:25:17,40 --> 03:25:22,479
+but we can take those after yeah let's
+
+5689
+03:25:20,159 --> 03:25:23,920
+quickly show the deletions so if we go
+
+5690
+03:25:22,478 --> 03:25:25,199
+to an event
+
+5691
+03:25:23,920 --> 03:25:27,279
+yeah i'll take i'll take a hundred
+
+5692
+03:25:25,200 --> 03:25:30,800
+members so this is a massive
+
+5693
+03:25:27,279 --> 03:25:32,319
+gotcha basic basically missed
+
+5694
+03:25:30,799 --> 03:25:33,840
+uh which we have some protective
+
+5695
+03:25:32,318 --> 03:25:34,799
+measures in place to avoid this but one
+
+5696
+03:25:33,840 --> 03:25:37,439
+of the things that you really need to
+
+5697
+03:25:34,799 --> 03:25:39,759
+watch out for is
+
+5698
+03:25:37,439 --> 03:25:40,479
+when you when you add data to misspen
+
+5699
+03:25:39,760 --> 03:25:42,398
+you notice
+
+5700
+03:25:40,478 --> 03:25:44,238
+oh crap i should not have added a piece
+
+5701
+03:25:42,398 --> 03:25:45,920
+of information that is
+
+5702
+03:25:44,238 --> 03:25:47,359
+either confidential information
+
+5703
+03:25:45,920 --> 03:25:49,520
+information about the victim that i
+
+5704
+03:25:47,359 --> 03:25:51,760
+should share and so on
+
+5705
+03:25:49,520 --> 03:25:53,279
+the attribute that attribute might still
+
+5706
+03:25:51,760 --> 03:25:55,200
+be contained in the event in a
+
+5707
+03:25:53,279 --> 03:25:57,200
+in a soft deleted format you can always
+
+5708
+03:25:55,200 --> 03:26:00,319
+toggle and see the deleted attributes
+
+5709
+03:25:57,200 --> 03:26:00,319
+uh within an event
+
+5710
+03:26:00,879 --> 03:26:05,39
+so i will create i will create an even
+
+5711
+03:26:02,559 --> 03:26:05,39
+from scratch
+
+5712
+03:26:05,840 --> 03:26:10,799
+okay so before i move forward on that so
+
+5713
+03:26:09,200 --> 03:26:13,120
+we have two protective measures in place
+
+5714
+03:26:10,799 --> 03:26:16,799
+to avoid accidental information leakage
+
+5715
+03:26:13,120 --> 03:26:18,479
+violation one is basically that
+
+5716
+03:26:16,799 --> 03:26:20,318
+that by default we do not use the
+
+5717
+03:26:18,478 --> 03:26:21,519
+software method for anything that was
+
+5718
+03:26:20,318 --> 03:26:23,519
+unpublished uh
+
+5719
+03:26:21,520 --> 03:26:24,960
+at first so we're going to show it as an
+
+5720
+03:26:23,520 --> 03:26:25,760
+example so here's some sensitive
+
+5721
+03:26:24,959 --> 03:26:27,599
+information
+
+5722
+03:26:25,760 --> 03:26:30,559
+if alex were to delete this now this
+
+5723
+03:26:27,600 --> 03:26:32,720
+attribute this would get our deleted
+
+5724
+03:26:30,559 --> 03:26:33,920
+so this will not create a soft deletion
+
+5725
+03:26:32,719 --> 03:26:35,760
+uh miss pareto
+
+5726
+03:26:33,920 --> 03:26:37,200
+tells us are you sure you want to hard
+
+5727
+03:26:35,760 --> 03:26:38,318
+delete the attribute so when you read
+
+5728
+03:26:37,200 --> 03:26:40,79
+the text you will see the see the
+
+5729
+03:26:38,318 --> 03:26:42,0
+12398.319 --> 12402
+difference there in the wording
+
+5730
+03:26:40,79 --> 03:26:43,520
+uh the reason for that is the event it
+
+5731
+03:26:42,0 --> 03:26:44,879
+12402 --> 12404.88
+has not been published yet we know that
+
+5732
+03:26:43,520 --> 03:26:46,79
+it has not probably been propagated to
+
+5733
+03:26:44,879 --> 03:26:48,0
+12404.88 --> 12408
+other instances
+
+5734
+03:26:46,79 --> 03:26:50,318
+there is absolutely no reason to inform
+
+5735
+03:26:48,0 --> 03:26:52,159
+12408 --> 12412.16
+anyone that this has been deleted
+
+5736
+03:26:50,318 --> 03:26:54,559
+so we can immediately just hard delete
+
+5737
+03:26:52,159 --> 03:26:56,559
+it so when we do that
+
+5738
+03:26:54,559 --> 03:26:58,238
+it will get hard deleted however if the
+
+5739
+03:26:56,559 --> 03:26:59,840
+event has already been published
+
+5740
+03:26:58,238 --> 03:27:01,760
+this has already been shared out to
+
+5741
+03:26:59,840 --> 03:27:03,920
+other instances potentially
+
+5742
+03:27:01,760 --> 03:27:05,439
+so in this case if we were to delete it
+
+5743
+03:27:03,920 --> 03:27:06,799
+miss will tell us oh
+
+5744
+03:27:05,439 --> 03:27:08,720
+are you sure you want to soft delete
+
+5745
+03:27:06,799 --> 03:27:10,79
+this attribute because this is already a
+
+5746
+03:27:08,719 --> 03:27:12,639
+published event
+
+5747
+03:27:10,79 --> 03:27:14,159
+now it looks like our event is empty but
+
+5748
+03:27:12,639 --> 03:27:15,519
+if you look at the deleted flag you will
+
+5749
+03:27:14,159 --> 03:27:16,318
+see that the sensitive attribute is
+
+5750
+03:27:15,520 --> 03:27:18,479
+still there
+
+5751
+03:27:16,318 --> 03:27:20,478
+and if i were to publish the event now
+
+5752
+03:27:18,478 --> 03:27:22,0
+12438.479 --> 12442
+this sensitive attribute would
+
+5753
+03:27:20,478 --> 03:27:25,39
+it would get propagated along with the
+
+5754
+03:27:22,0 --> 03:27:27,359
+12442 --> 12447.359
+event if you want to avoid this
+
+5755
+03:27:25,40 --> 03:27:29,200
+altogether there is a way to mangle any
+
+5756
+03:27:27,359 --> 03:27:31,680
+attribute that gets self-deleted
+
+5757
+03:27:29,200 --> 03:27:32,800
+what happens in that case is a category
+
+5758
+03:27:31,680 --> 03:27:34,800
+will be set to other
+
+5759
+03:27:32,799 --> 03:27:36,639
+type will be set to other and value will
+
+5760
+03:27:34,799 --> 03:27:38,639
+be set to redacted
+
+5761
+03:27:36,639 --> 03:27:39,920
+this is a server-wide setting so your
+
+5762
+03:27:38,639 --> 03:27:41,519
+administrator or if you are the
+
+5763
+03:27:39,920 --> 03:27:44,318
+administrator and yourself can set this
+
+5764
+03:27:41,520 --> 03:27:46,159
+setting in the server settings
+
+5765
+03:27:44,318 --> 03:27:47,519
+the downside of that is if you are
+
+5766
+03:27:46,159 --> 03:27:49,200
+mangling attributes that you're soft
+
+5767
+03:27:47,520 --> 03:27:51,279
+deleting it will still inform the other
+
+5768
+03:27:49,200 --> 03:27:52,880
+instances they will still
+
+5769
+03:27:51,279 --> 03:27:55,40
+remove the data software the data
+
+5770
+03:27:52,879 --> 03:27:57,278
+because the uid is reserved
+
+5771
+03:27:55,40 --> 03:27:58,239
+however you cannot recover the attribute
+
+5772
+03:27:57,279 --> 03:28:00,238
+anymore so if
+
+5773
+03:27:58,238 --> 03:28:01,760
+so in this case right now we deleted
+
+5774
+03:28:00,238 --> 03:28:02,799
+attribute alex could now click on the
+
+5775
+03:28:01,760 --> 03:28:04,639
+recover button
+
+5776
+03:28:02,799 --> 03:28:06,79
+and the attribute will be recovered as a
+
+5777
+03:28:04,639 --> 03:28:07,920
+normal attribute so if you made a
+
+5778
+03:28:06,79 --> 03:28:11,39
+mistake you can recover it
+
+5779
+03:28:07,920 --> 03:28:12,879
+so there are two different mindsets i
+
+5780
+03:28:11,40 --> 03:28:14,960
+want to make my data recoverable
+
+5781
+03:28:12,879 --> 03:28:17,278
+versus and i want to always inform
+
+5782
+03:28:14,959 --> 03:28:20,79
+others versus i want to always
+
+5783
+03:28:17,279 --> 03:28:21,359
+hard delete data that i delete both of
+
+5784
+03:28:20,79 --> 03:28:23,520
+them have a setting
+
+5785
+03:28:21,359 --> 03:28:25,40
+so just pick and choose which whichever
+
+5786
+03:28:23,520 --> 03:28:27,680
+makes sense for your community
+
+5787
+03:28:25,40 --> 03:28:28,479
+whether you prefer secrecy or prefer
+
+5788
+03:28:27,680 --> 03:28:32,79
+convenience
+
+5789
+03:28:28,478 --> 03:28:34,159
+uh basically so it's basically
+
+5790
+03:28:32,79 --> 03:28:35,200
+yeah that's delete for that review so if
+
+5791
+03:28:34,159 --> 03:28:38,318
+we delete an
+
+5792
+03:28:35,200 --> 03:28:41,120
+event that's another story yeah and this
+
+5793
+03:28:38,318 --> 03:28:42,398
+this one is interesting because now we
+
+5794
+03:28:41,120 --> 03:28:44,640
+have these options where we say
+
+5795
+03:28:42,398 --> 03:28:46,79
+i want to delete this event and
+
+5796
+03:28:44,639 --> 03:28:46,799
+obviously it will be deleted on your
+
+5797
+03:28:46,79 --> 03:28:49,200
+instance
+
+5798
+03:28:46,799 --> 03:28:50,159
+nevertheless this even has been already
+
+5799
+03:28:49,200 --> 03:28:52,159
+synchronized
+
+5800
+03:28:50,159 --> 03:28:53,200
+copy and develop different misc
+
+5801
+03:28:52,159 --> 03:28:54,398
+instances
+
+5802
+03:28:53,200 --> 03:28:56,239
+so that means as the next
+
+5803
+03:28:54,398 --> 03:28:57,39
+synchronizations the event should be
+
+5804
+03:28:56,238 --> 03:28:59,920
+pulled
+
+5805
+03:28:57,40 --> 03:29:01,680
+but to avoid such kind of of issue mist
+
+5806
+03:28:59,920 --> 03:29:05,520
+is automatically generating
+
+5807
+03:29:01,680 --> 03:29:07,359
+a block list of all those elite events
+
+5808
+03:29:05,520 --> 03:29:09,600
+so if you are the administrator you can
+
+5809
+03:29:07,359 --> 03:29:12,238
+see at the block list of events
+
+5810
+03:29:09,600 --> 03:29:13,120
+you can see the the one that i just
+
+5811
+03:29:12,238 --> 03:29:16,238
+deleted
+
+5812
+03:29:13,120 --> 03:29:18,720
+so why we do that it's very simple
+
+5813
+03:29:16,238 --> 03:29:20,238
+we don't want to re-import the event
+
+5814
+03:29:18,719 --> 03:29:21,358
+that has been deleted because luckily we
+
+5815
+03:29:20,238 --> 03:29:23,680
+don't want this event
+
+5816
+03:29:21,359 --> 03:29:25,520
+so it's a it's a block list of all the
+
+5817
+03:29:23,680 --> 03:29:28,720
+cgas
+
+5818
+03:29:25,520 --> 03:29:30,399
+but this this catch there uh sometimes
+
+5819
+03:29:28,719 --> 03:29:31,760
+we have people oh i'm doing some tests
+
+5820
+03:29:30,398 --> 03:29:33,439
+and so on i'm synchronizing with miss
+
+5821
+03:29:31,760 --> 03:29:35,439
+but i can't see my even back
+
+5822
+03:29:33,439 --> 03:29:36,479
+and obviously yes because it's there in
+
+5823
+03:29:35,439 --> 03:29:37,840
+this block list
+
+5824
+03:29:36,478 --> 03:29:39,358
+so if you have some tests and you're
+
+5825
+03:29:37,840 --> 03:29:40,398
+running some tests don't forget to look
+
+5826
+03:29:39,359 --> 03:29:44,159
+at the block list
+
+5827
+03:29:40,398 --> 03:29:46,318
+and maybe you want to just remove
+
+5828
+03:29:44,159 --> 03:29:48,719
+the event for the block keys and then
+
+5829
+03:29:46,318 --> 03:29:50,478
+you can synchronize back the event
+
+5830
+03:29:48,719 --> 03:29:52,559
+there's something to keep in mind it's
+
+5831
+03:29:50,478 --> 03:29:54,79
+there it's done automatically but in
+
+5832
+03:29:52,559 --> 03:29:54,799
+some cases you want to manage the
+
+5833
+03:29:54,79 --> 03:29:58,0
+12594.08 --> 12598
+blockly
+
+5834
+03:29:54,799 --> 03:30:01,519
+so that's something to keep in mind
+
+5835
+03:29:58,0 --> 03:30:04,478
+12598 --> 12604.479
+yep something else
+
+5836
+03:30:01,520 --> 03:30:06,79
+that we perhaps should uh touch on here
+
+5837
+03:30:04,478 --> 03:30:08,799
+is is
+
+5838
+03:30:06,79 --> 03:30:09,760
+for the event deletions besides just a
+
+5839
+03:30:08,799 --> 03:30:11,119
+blockless part
+
+5840
+03:30:09,760 --> 03:30:12,800
+there is one thing that comes up as a
+
+5841
+03:30:11,120 --> 03:30:15,40
+question very often is how do i inform
+
+5842
+03:30:12,799 --> 03:30:16,639
+others that an event needs to be removed
+
+5843
+03:30:15,40 --> 03:30:19,40
+we don't have a mechanism in place for
+
+5844
+03:30:16,639 --> 03:30:21,519
+that so while we can revoke attributes
+
+5845
+03:30:19,40 --> 03:30:23,120
+for events uh we don't have that and
+
+5846
+03:30:21,520 --> 03:30:25,279
+there's a reason for that
+
+5847
+03:30:23,120 --> 03:30:26,239
+in general uh whenever it comes to
+
+5848
+03:30:25,279 --> 03:30:29,200
+events uh
+
+5849
+03:30:26,238 --> 03:30:30,639
+we don't want to give the power to just
+
+5850
+03:30:29,200 --> 03:30:33,439
+outright delete
+
+5851
+03:30:30,639 --> 03:30:34,719
+events uh remotely this way so this
+
+5852
+03:30:33,439 --> 03:30:36,238
+might change in the future
+
+5853
+03:30:34,719 --> 03:30:37,920
+we we're having discussions on that
+
+5854
+03:30:36,238 --> 03:30:40,79
+whether we want to enable that or not
+
+5855
+03:30:37,920 --> 03:30:41,840
+but currently that's not the case yeah
+
+5856
+03:30:40,79 --> 03:30:44,398
+and usually we take as an example
+
+5857
+03:30:41,840 --> 03:30:46,0
+12641.84 --> 12646
+emails i mean you can remove emails from
+
+5858
+03:30:44,398 --> 03:30:47,358
+your personal mailbox but from the
+
+5859
+03:30:46,0 --> 03:30:49,120
+12646 --> 12649.12
+remote mailbox if someone already
+
+5860
+03:30:47,359 --> 03:30:51,279
+receives the emails
+
+5861
+03:30:49,120 --> 03:30:53,120
+you want to have the control over third
+
+5862
+03:30:51,279 --> 03:30:58,79
+parties on the mailbox that
+
+5863
+03:30:53,120 --> 03:31:00,239
+might be one of the drawback i would say
+
+5864
+03:30:58,79 --> 03:31:01,760
+so there are two two new questions one
+
+5865
+03:31:00,238 --> 03:31:03,439
+of them is basically can you demonstrate
+
+5866
+03:31:01,760 --> 03:31:05,200
+the progressive enrichments of events
+
+5867
+03:31:03,439 --> 03:31:06,559
+by the shared communities over time with
+
+5868
+03:31:05,200 --> 03:31:08,960
+correlations
+
+5869
+03:31:06,559 --> 03:31:10,398
+this one is tough i mean i'm not sure
+
+5870
+03:31:08,959 --> 03:31:11,278
+how we could demonstrate that because
+
+5871
+03:31:10,398 --> 03:31:14,159
+we're not dealing with
+
+5872
+03:31:11,279 --> 03:31:14,560
+live instances with live data sets and
+
+5873
+03:31:14,159 --> 03:31:17,279
+act
+
+5874
+03:31:14,559 --> 03:31:17,278
+active sharing
+
+5875
+03:31:17,840 --> 03:31:23,40
+but perhaps for tomorrow we will prepare
+
+5876
+03:31:19,680 --> 03:31:25,520
+an example where we can show it off
+
+5877
+03:31:23,40 --> 03:31:28,640
+when and choose an event that we can
+
+5878
+03:31:25,520 --> 03:31:31,120
+show on one of the operational instances
+
+5879
+03:31:28,639 --> 03:31:33,119
+but i i can't show one on uh you know
+
+5880
+03:31:31,120 --> 03:31:36,560
+what i can't go on
+
+5881
+03:31:33,120 --> 03:31:38,79
+just one thing i'm i'm going on an
+
+5882
+03:31:36,559 --> 03:31:41,760
+instance
+
+5883
+03:31:38,79 --> 03:31:43,760
+okay so so it was
+
+5884
+03:31:41,760 --> 03:31:45,200
+oh we are flexible so it's not super fun
+
+5885
+03:31:43,760 --> 03:31:48,318
+to do it no but
+
+5886
+03:31:45,200 --> 03:31:49,359
+um so it's maybe some some something
+
+5887
+03:31:48,318 --> 03:31:52,0
+12708.319 --> 12712
+interesting there
+
+5888
+03:31:49,359 --> 03:31:52,720
+um so um i'm connecting an instance
+
+5889
+03:31:52,0 --> 03:31:55,760
+12712 --> 12715.76
+where i have
+
+5890
+03:31:52,719 --> 03:31:57,278
+more expansion services uh active and so
+
+5891
+03:31:55,760 --> 03:31:59,200
+on
+
+5892
+03:31:57,279 --> 03:32:01,40
+i'll just keep it for my organization
+
+5893
+03:31:59,200 --> 03:32:05,520
+only so i'm creating
+
+5894
+03:32:01,40 --> 03:32:07,600
+an event there so what happens on
+
+5895
+03:32:05,520 --> 03:32:08,960
+progressively enriching even by shared
+
+5896
+03:32:07,600 --> 03:32:10,479
+communities i mean
+
+5897
+03:32:08,959 --> 03:32:12,159
+it's going back and forth to different
+
+5898
+03:32:10,478 --> 03:32:14,559
+communities but i can i can imitate what
+
+5899
+03:32:12,159 --> 03:32:18,159
+the community is doing usually
+
+5900
+03:32:14,559 --> 03:32:21,600
+so if i'm facing an attribute
+
+5901
+03:32:18,159 --> 03:32:26,398
+for example i will i will say it
+
+5902
+03:32:21,600 --> 03:32:26,399
+hostname with some network activity
+
+5903
+03:32:32,959 --> 03:32:36,879
+so we have specifically a test that we
+
+5904
+03:32:35,680 --> 03:32:39,439
+created with this
+
+5905
+03:32:36,879 --> 03:32:40,559
+kind of thing so what would be your
+
+5906
+03:32:39,439 --> 03:32:41,920
+community and
+
+5907
+03:32:40,559 --> 03:32:43,600
+sharing so it could be for example in
+
+5908
+03:32:41,920 --> 03:32:45,680
+the same organization in my case it's
+
+5909
+03:32:43,600 --> 03:32:48,800
+just clear to the organization so
+
+5910
+03:32:45,680 --> 03:32:50,0
+12765.68 --> 12770
+if i publish event here it will be
+
+5911
+03:32:48,799 --> 03:32:51,519
+shared with
+
+5912
+03:32:50,0 --> 03:32:53,520
+12770 --> 12773.52
+all different instances maybe the
+
+5913
+03:32:51,520 --> 03:32:57,680
+different members of circle
+
+5914
+03:32:53,520 --> 03:33:01,840
+uh and um one of my colleagues
+
+5915
+03:32:57,680 --> 03:33:04,720
+is taking one of the indicators
+
+5916
+03:33:01,840 --> 03:33:05,760
+and then he's going on the far side
+
+5917
+03:33:04,719 --> 03:33:07,599
+database
+
+5918
+03:33:05,760 --> 03:33:09,120
+doing a full-blown expansion so that
+
+5919
+03:33:07,600 --> 03:33:10,159
+means he's basically doing a full-bone
+
+5920
+03:33:09,120 --> 03:33:13,760
+extension
+
+5921
+03:33:10,159 --> 03:33:16,959
+um what do i have here i have a
+
+5922
+03:33:13,760 --> 03:33:18,719
+a complete set of objects for a specific
+
+5923
+03:33:16,959 --> 03:33:22,318
+domain so you see again
+
+5924
+03:33:18,719 --> 03:33:25,39
+i'm going to the event graph
+
+5925
+03:33:22,318 --> 03:33:25,680
+now i enter my domain name and i have
+
+5926
+03:33:25,40 --> 03:33:27,359
+all the
+
+5927
+03:33:25,680 --> 03:33:28,960
+passive dns free curve associated to
+
+5928
+03:33:27,359 --> 03:33:31,760
+that one
+
+5929
+03:33:28,959 --> 03:33:33,199
+and in this one i think i will have the
+
+5930
+03:33:31,760 --> 03:33:35,520
+even timeline i have a completely
+
+5931
+03:33:33,200 --> 03:33:38,960
+different timeline of the different uh
+
+5932
+03:33:35,520 --> 03:33:42,238
+expansion and so on so then i will have
+
+5933
+03:33:38,959 --> 03:33:42,879
+one of my i will it will be published
+
+5934
+03:33:42,238 --> 03:33:45,209
+again
+
+5935
+03:33:42,879 --> 03:33:46,719
+with the uh with the data
+
+5936
+03:33:45,209 --> 03:33:48,879
+[Music]
+
+5937
+03:33:46,719 --> 03:33:50,79
+if it's a collaboration i would say in
+
+5938
+03:33:48,879 --> 03:33:52,799
+the same team
+
+5939
+03:33:50,79 --> 03:33:53,359
+that's a thing so it's sometimes it's
+
+5940
+03:33:52,799 --> 03:33:55,119
+it's
+
+5941
+03:33:53,359 --> 03:33:57,439
+people are working on the same event and
+
+5942
+03:33:55,120 --> 03:33:59,359
+publishing it sometimes they are
+
+5943
+03:33:57,439 --> 03:34:01,359
+sharing it and doing additional
+
+5944
+03:33:59,359 --> 03:34:04,880
+expansion on the uh
+
+5945
+03:34:01,359 --> 03:34:08,79
+on the um things until to reach a
+
+5946
+03:34:04,879 --> 03:34:11,39
+specific point that is like i would say
+
+5947
+03:34:08,79 --> 03:34:12,398
+accessible or at least publishable in a
+
+5948
+03:34:11,40 --> 03:34:16,0
+12851.04 --> 12856
+publishing state that is
+
+5949
+03:34:12,398 --> 03:34:18,318
+acceptable by various people
+
+5950
+03:34:16,0 --> 03:34:19,520
+12856 --> 12859.52
+now we can make proposal too so that
+
+5951
+03:34:18,318 --> 03:34:22,79
+means
+
+5952
+03:34:19,520 --> 03:34:24,880
+if we are again on a different with a
+
+5953
+03:34:22,79 --> 03:34:26,478
+different organization
+
+5954
+03:34:24,879 --> 03:34:28,79
+i don't know if in this example it will
+
+5955
+03:34:26,478 --> 03:34:30,719
+work but i can
+
+5956
+03:34:28,79 --> 03:34:32,879
+take do i have something interesting
+
+5957
+03:34:30,719 --> 03:34:32,879
+there
+
+5958
+03:34:33,760 --> 03:34:37,680
+yeah for example i see an interesting
+
+5959
+03:34:35,359 --> 03:34:37,680
+ipl
+
+5960
+03:34:37,840 --> 03:34:43,840
+this one so what i could do is
+
+5961
+03:34:41,279 --> 03:34:43,840
+i could
+
+5962
+03:34:44,398 --> 03:34:46,719
+add
+
+5963
+03:34:49,600 --> 03:34:52,479
+what's going on here
+
+5964
+03:34:53,40 --> 03:34:57,40
+i will add what
+
+5965
+03:35:04,159 --> 03:35:14,0
+12904.16 --> 12914
+okay just a demo effect
+
+5966
+03:35:10,799 --> 03:35:18,238
+it's a great typical
+
+5967
+03:35:14,0 --> 03:35:18,238
+12914 --> 12918.239
+what's going on here okay
+
+5968
+03:35:19,439 --> 03:35:25,40
+just going back to this one i just want
+
+5969
+03:35:21,600 --> 03:35:28,0
+12921.6 --> 12928
+to add a proposal
+
+5970
+03:35:25,40 --> 03:35:28,0
+12925.04 --> 12928
+yes i cannot just
+
+5971
+03:35:28,959 --> 03:35:35,839
+you wanted but your admin yeah
+
+5972
+03:35:33,200 --> 03:35:36,479
+yeah then i don't you can cheat whether
+
+5973
+03:35:35,840 --> 03:35:38,478
+you
+
+5974
+03:35:36,478 --> 03:35:40,0
+12936.479 --> 12940
+really want you can do it yeah wait fine
+
+5975
+03:35:38,478 --> 03:35:43,39
+it's just like okay so
+
+5976
+03:35:40,0 --> 03:35:44,799
+12940 --> 12944.8
+i i don't know for for hong kong if we
+
+5977
+03:35:43,40 --> 03:35:47,840
+answer your question but i mean
+
+5978
+03:35:44,799 --> 03:35:49,519
+a full-blown step would be like that if
+
+5979
+03:35:47,840 --> 03:35:50,559
+you work on an event it's not a single
+
+5980
+03:35:49,520 --> 03:35:52,399
+person obviously
+
+5981
+03:35:50,559 --> 03:35:54,238
+when you do an investigation you do like
+
+5982
+03:35:52,398 --> 03:35:54,799
+multiple steps but the question is more
+
+5983
+03:35:54,238 --> 03:35:56,879
+like
+
+5984
+03:35:54,799 --> 03:35:58,799
+if you do it within a team usually you
+
+5985
+03:35:56,879 --> 03:36:00,0
+12956.88 --> 12960
+edit the current even the same
+
+5986
+03:35:58,799 --> 03:36:03,519
+organizations
+
+5987
+03:36:00,0 --> 03:36:05,760
+12960 --> 12965.76
+if you do enter team you do proposal
+
+5988
+03:36:03,520 --> 03:36:07,680
+extend it even like we showed before and
+
+5989
+03:36:05,760 --> 03:36:09,359
+then you start to work on this uh
+
+5990
+03:36:07,680 --> 03:36:11,279
+thing so it's here depending on the case
+
+5991
+03:36:09,359 --> 03:36:13,600
+so uh
+
+5992
+03:36:11,279 --> 03:36:15,680
+so i hope you can you can you can see
+
+5993
+03:36:13,600 --> 03:36:18,318
+what are the capabilities there but it's
+
+5994
+03:36:15,680 --> 03:36:20,398
+really uh the progressive approach of
+
+5995
+03:36:18,318 --> 03:36:22,559
+collaboration usually depends of
+
+5996
+03:36:20,398 --> 03:36:24,478
+how people are working together if they
+
+5997
+03:36:22,559 --> 03:36:25,680
+are really external it's more proposal
+
+5998
+03:36:24,478 --> 03:36:28,79
+extended event
+
+5999
+03:36:25,680 --> 03:36:29,279
+if it's within the same team it could be
+
+6000
+03:36:28,79 --> 03:36:31,439
+extended event
+
+6001
+03:36:29,279 --> 03:36:33,920
+or within the same event that's usually
+
+6002
+03:36:31,439 --> 03:36:37,120
+the two way of working
+
+6003
+03:36:33,920 --> 03:36:39,680
+if you want to add something no yeah
+
+6004
+03:36:37,120 --> 03:36:39,680
+that's perfect
+
+6005
+03:36:39,760 --> 03:36:43,279
+perhaps another question if you're okay
+
+6006
+03:36:42,639 --> 03:36:46,719
+with
+
+6007
+03:36:43,279 --> 03:36:48,0
+13003.279 --> 13008
+switching yeah when speaking of feeding
+
+6008
+03:36:46,719 --> 03:36:49,840
+tools what would be the automatic
+
+6009
+03:36:48,0 --> 03:36:51,120
+13008 --> 13011.12
+way of doing it so normally when we're
+
+6010
+03:36:49,840 --> 03:36:52,639
+talking about feeding tools there are
+
+6011
+03:36:51,120 --> 03:36:54,720
+two separate ways of doing it and we'll
+
+6012
+03:36:52,639 --> 03:36:56,159
+go way way deeper into this tomorrow
+
+6013
+03:36:54,719 --> 03:36:58,238
+when we talk about integration but
+
+6014
+03:36:56,159 --> 03:36:58,959
+generally tools can either fetch data
+
+6015
+03:36:58,238 --> 03:37:00,559
+from miss
+
+6016
+03:36:58,959 --> 03:37:02,799
+so this is a more common way where a
+
+6017
+03:37:00,559 --> 03:37:05,119
+tool would use rest search api that we
+
+6018
+03:37:02,799 --> 03:37:07,278
+mentioned before where you define yours
+
+6019
+03:37:05,120 --> 03:37:09,40
+your search patterns for example give me
+
+6020
+03:37:07,279 --> 03:37:12,159
+everything that is newer than
+
+6021
+03:37:09,40 --> 03:37:12,880
+30 days everything that uh that contains
+
+6022
+03:37:12,159 --> 03:37:15,760
+at least
+
+6023
+03:37:12,879 --> 03:37:16,398
+that is not coming from say oh since the
+
+6024
+03:37:15,760 --> 03:37:18,719
+sources
+
+6025
+03:37:16,398 --> 03:37:19,599
+or perhaps not something nothing that
+
+6026
+03:37:18,719 --> 03:37:21,760
+comes
+
+6027
+03:37:19,600 --> 03:37:23,520
+uh related to a certain topic for
+
+6028
+03:37:21,760 --> 03:37:25,600
+example i'm not interested in ransomware
+
+6029
+03:37:23,520 --> 03:37:26,399
+when feeding my tools just a stupid
+
+6030
+03:37:25,600 --> 03:37:28,640
+example
+
+6031
+03:37:26,398 --> 03:37:30,159
+so you set up your filter options and
+
+6032
+03:37:28,639 --> 03:37:32,318
+then your tool would fetch
+
+6033
+03:37:30,159 --> 03:37:33,680
+data from misp every 60 minutes for
+
+6034
+03:37:32,318 --> 03:37:36,159
+example
+
+6035
+03:37:33,680 --> 03:37:37,359
+and then replace the data set there you
+
+6036
+03:37:36,159 --> 03:37:40,318
+can also do
+
+6037
+03:37:37,359 --> 03:37:42,79
+sliding time window searches where you
+
+6038
+03:37:40,318 --> 03:37:43,760
+say give me everything from the past 60
+
+6039
+03:37:42,79 --> 03:37:45,359
+minutes that is new
+
+6040
+03:37:43,760 --> 03:37:48,0
+13063.76 --> 13068
+and then you keep concatenating your
+
+6041
+03:37:45,359 --> 03:37:49,40
+data set on the seam side ids side
+
+6042
+03:37:48,0 --> 03:37:51,200
+13068 --> 13071.2
+whatever tool you're
+
+6043
+03:37:49,40 --> 03:37:52,880
+feeding the alternative if you want to
+
+6044
+03:37:51,200 --> 03:37:53,680
+have the data push automatically as it
+
+6045
+03:37:52,879 --> 03:37:55,199
+comes in
+
+6046
+03:37:53,680 --> 03:37:57,40
+you have different channels and mist
+
+6047
+03:37:55,200 --> 03:37:58,560
+that your tools can latch on to
+
+6048
+03:37:57,40 --> 03:38:00,720
+the downside being that you still need
+
+6049
+03:37:58,559 --> 03:38:03,199
+to do the conversion
+
+6050
+03:38:00,719 --> 03:38:04,959
+in those cases so if you were not using
+
+6051
+03:38:03,200 --> 03:38:08,159
+the
+
+6052
+03:38:04,959 --> 03:38:11,199
+the apis to fetch the data from bisp
+
+6053
+03:38:08,159 --> 03:38:11,680
+then mis can push using the miss json
+
+6054
+03:38:11,200 --> 03:38:13,680
+format
+
+6055
+03:38:11,680 --> 03:38:16,0
+13091.68 --> 13096
+data down via different channels serum
+
+6056
+03:38:13,680 --> 03:38:16,0
+13093.68 --> 13096
+queue
+
+6057
+03:38:16,79 --> 03:38:19,760
+or the kafka channel or this blog and so
+
+6058
+03:38:19,279 --> 03:38:21,279
+on
+
+6059
+03:38:19,760 --> 03:38:23,40
+and then your tools automatically feed
+
+6060
+03:38:21,279 --> 03:38:24,0
+13101.279 --> 13104
+on that data so you have these two
+
+6061
+03:38:23,40 --> 03:38:26,399
+different
+
+6062
+03:38:24,0 --> 03:38:27,520
+13104 --> 13107.52
+ways of interacting with it there's also
+
+6063
+03:38:26,398 --> 03:38:28,959
+a third way
+
+6064
+03:38:27,520 --> 03:38:31,760
+where you can basically either build an
+
+6065
+03:38:28,959 --> 03:38:34,0
+13108.96 --> 13114
+export module or an enrichment module
+
+6066
+03:38:31,760 --> 03:38:35,760
+where an analyst can trigger a direct
+
+6067
+03:38:34,0 --> 03:38:38,559
+13114 --> 13118.56
+push of a certain data point
+
+6068
+03:38:35,760 --> 03:38:39,920
+to another tool so that's another option
+
+6069
+03:38:38,559 --> 03:38:41,840
+we'll talk about these different
+
+6070
+03:38:39,920 --> 03:38:45,199
+strategies when to use which
+
+6071
+03:38:41,840 --> 03:38:49,199
+which and how to mix those tomorrow more
+
+6072
+03:38:45,199 --> 03:38:52,399
+so i hope that answers it in a
+
+6073
+03:38:49,199 --> 03:38:54,159
+brief fashion yeah what i'm showing here
+
+6074
+03:38:52,398 --> 03:38:57,840
+is it's just like
+
+6075
+03:38:54,159 --> 03:38:59,359
+on the on the rest uh search client
+
+6076
+03:38:57,840 --> 03:39:01,760
+for example you want to feed your your
+
+6077
+03:38:59,359 --> 03:39:04,800
+storikata and so on uh just
+
+6078
+03:39:01,760 --> 03:39:09,840
+take page um
+
+6079
+03:39:04,799 --> 03:39:09,840
+on a specific limit
+
+6080
+03:39:13,359 --> 03:39:17,199
+so what you can do is if you have a
+
+6081
+03:39:15,600 --> 03:39:19,120
+python script and so on you can pull
+
+6082
+03:39:17,199 --> 03:39:22,159
+directly the data so
+
+6083
+03:39:19,120 --> 03:39:23,199
+the rest client so you see in this case
+
+6084
+03:39:22,159 --> 03:39:26,159
+i have the
+
+6085
+03:39:23,199 --> 03:39:26,880
+shurikata rule set but if you want to
+
+6086
+03:39:26,159 --> 03:39:29,359
+feed your
+
+6087
+03:39:26,879 --> 03:39:31,358
+specific tools and and so on uh
+
+6088
+03:39:29,359 --> 03:39:34,960
+automatically we are generating
+
+6089
+03:39:31,359 --> 03:39:36,399
+uh curl and python card so it could be a
+
+6090
+03:39:34,959 --> 03:39:38,639
+bootstrap to see okay
+
+6091
+03:39:36,398 --> 03:39:41,119
+how should i create my own tool for
+
+6092
+03:39:38,639 --> 03:39:42,639
+feeding my ideas and so on uh for for
+
+6093
+03:39:41,120 --> 03:39:44,399
+study cata for example
+
+6094
+03:39:42,639 --> 03:39:45,840
+a lot of management interface have
+
+6095
+03:39:44,398 --> 03:39:47,760
+already missed connector
+
+6096
+03:39:45,840 --> 03:39:49,120
+so you can even like feed the data
+
+6097
+03:39:47,760 --> 03:39:51,600
+directly from
+
+6098
+03:39:49,120 --> 03:39:52,319
+the from the interface if they have the
+
+6099
+03:39:51,600 --> 03:39:54,720
+ability
+
+6100
+03:39:52,318 --> 03:39:56,639
+splunk for example there's a specific
+
+6101
+03:39:54,719 --> 03:40:00,79
+application
+
+6102
+03:39:56,639 --> 03:40:02,799
+which is an external tools part of the
+
+6103
+03:40:00,79 --> 03:40:04,79
+app store of splunk that you can install
+
+6104
+03:40:02,799 --> 03:40:05,759
+for doing the connection
+
+6105
+03:40:04,79 --> 03:40:08,639
+and some other people are using their
+
+6106
+03:40:05,760 --> 03:40:12,159
+own python script to feed other cm
+
+6107
+03:40:08,639 --> 03:40:14,238
+so again it's a matter of taste
+
+6108
+03:40:12,159 --> 03:40:16,0
+13212.16 --> 13216
+if you are curious about the different
+
+6109
+03:40:14,238 --> 03:40:18,79
+kind of integrations
+
+6110
+03:40:16,0 --> 03:40:20,79
+13216 --> 13220.08
+or you can do it in python for example
+
+6111
+03:40:18,79 --> 03:40:24,79
+in on payments
+
+6112
+03:40:20,79 --> 03:40:26,478
+itself there are plenty of examples
+
+6113
+03:40:24,79 --> 03:40:28,959
+so if you go in the example directory of
+
+6114
+03:40:26,478 --> 03:40:28,959
+palmist
+
+6115
+03:40:30,799 --> 03:40:38,0
+13230.8 --> 13238
+you have a quite significant
+
+6116
+03:40:34,799 --> 03:40:41,438
+set of default scripts
+
+6117
+03:40:38,0 --> 03:40:43,40
+13238 --> 13243.04
+that you can use uh and that's uh
+
+6118
+03:40:41,439 --> 03:40:46,159
+i think usually a good basis if you want
+
+6119
+03:40:43,40 --> 03:40:48,720
+to start to to write your own custom
+
+6120
+03:40:46,159 --> 03:40:49,520
+custom tool set for for feeding your
+
+6121
+03:40:48,719 --> 03:40:51,278
+feeding
+
+6122
+03:40:49,520 --> 03:40:53,920
+systems or existing software in your
+
+6123
+03:40:51,279 --> 03:40:53,920
+infrastructure
+
+6124
+03:40:57,199 --> 03:41:03,760
+yep um
+
+6125
+03:41:01,680 --> 03:41:05,359
+i don't know if it's if we should jump
+
+6126
+03:41:03,760 --> 03:41:07,600
+on a new topic or we just push the
+
+6127
+03:41:05,359 --> 03:41:10,479
+copalos example for tomorrow
+
+6128
+03:41:07,600 --> 03:41:12,79
+yeah i think i think uh we can we can do
+
+6129
+03:41:10,478 --> 03:41:14,398
+it maybe tomorrow i think
+
+6130
+03:41:12,79 --> 03:41:15,920
+if we can i think that would be
+
+6131
+03:41:14,398 --> 03:41:17,519
+stretching it a little bit if we were to
+
+6132
+03:41:15,920 --> 03:41:21,40
+start with that yeah
+
+6133
+03:41:17,520 --> 03:41:22,0
+13277.52 --> 13282
+so um quick quick summary of today so
+
+6134
+03:41:21,40 --> 03:41:25,40
+today we we
+
+6135
+03:41:22,0 --> 03:41:26,79
+13282 --> 13286.08
+show uh how to create an event the basis
+
+6136
+03:41:25,40 --> 03:41:28,319
+of misplay
+
+6137
+03:41:26,79 --> 03:41:29,840
+what is an attribute an object and so on
+
+6138
+03:41:28,318 --> 03:41:32,959
+how to create it so to
+
+6139
+03:41:29,840 --> 03:41:34,79
+make proposal delete uh and and and
+
+6140
+03:41:32,959 --> 03:41:36,238
+stuff like that
+
+6141
+03:41:34,79 --> 03:41:37,840
+so it's really a simple example tomorrow
+
+6142
+03:41:36,238 --> 03:41:40,639
+we want to show you
+
+6143
+03:41:37,840 --> 03:41:42,639
+more the uh even report aspect and the
+
+6144
+03:41:40,639 --> 03:41:45,439
+automatic imports into
+
+6145
+03:41:42,639 --> 03:41:46,879
+into mist with a practical example of an
+
+6146
+03:41:45,439 --> 03:41:49,920
+ocean report
+
+6147
+03:41:46,879 --> 03:41:51,438
+and we will discuss tomorrow about
+
+6148
+03:41:49,920 --> 03:41:53,40
+how to build sharing communities and
+
+6149
+03:41:51,439 --> 03:41:55,840
+especially we will share
+
+6150
+03:41:53,40 --> 03:41:57,279
+our experience of things that worked and
+
+6151
+03:41:55,840 --> 03:41:59,520
+things that didn't work
+
+6152
+03:41:57,279 --> 03:42:01,359
+uh in the past years when creating
+
+6153
+03:41:59,520 --> 03:42:03,40
+sharing communities so if you are
+
+6154
+03:42:01,359 --> 03:42:04,479
+isaac members or creating your own
+
+6155
+03:42:03,40 --> 03:42:05,600
+sharing community even within your
+
+6156
+03:42:04,478 --> 03:42:07,39
+organization
+
+6157
+03:42:05,600 --> 03:42:09,40
+uh it's it's something good to
+
+6158
+03:42:07,40 --> 03:42:10,560
+participate because you we will share
+
+6159
+03:42:09,40 --> 03:42:12,479
+with you some some of the things that
+
+6160
+03:42:10,559 --> 03:42:14,238
+are interesting of building a
+
+6161
+03:42:12,478 --> 03:42:17,519
+bootstrapping such kind of
+
+6162
+03:42:14,238 --> 03:42:19,279
+of community um
+
+6163
+03:42:17,520 --> 03:42:20,800
+i don't know honestly you want to add
+
+6164
+03:42:19,279 --> 03:42:24,319
+something no
+
+6165
+03:42:20,799 --> 03:42:25,920
+and that's basically it thanks for
+
+6166
+03:42:24,318 --> 03:42:27,278
+everyone for sticking through
+
+6167
+03:42:25,920 --> 03:42:29,120
+through this it's a very condensed
+
+6168
+03:42:27,279 --> 03:42:30,880
+session so
+
+6169
+03:42:29,120 --> 03:42:32,560
+we said we didn't make as much progress
+
+6170
+03:42:30,879 --> 03:42:33,920
+as we hoped so we have quite a bit left
+
+6171
+03:42:32,559 --> 03:42:37,198
+for tomorrow
+
+6172
+03:42:33,920 --> 03:42:39,120
+and hope to see you all here tomorrow
+
+6173
+03:42:37,199 --> 03:42:40,800
+thank you very much uh take care and
+
+6174
+03:42:39,120 --> 03:42:43,279
+don't hesitate to ask questions
+
+6175
+03:42:40,799 --> 03:42:44,318
+uh either later on directly contact us
+
+6176
+03:42:43,279 --> 03:42:48,79
+thank you very much
+
+6177
+03:42:44,318 --> 03:42:48,79
+see you tomorrow thank you all see you
+
+6178
+03:42:49,318 --> 03:42:52,318
+tomorrow


### PR DESCRIPTION
I took the auto-generated subtitles from "MISP General Usage Training - Part 1 of 2" and cleaned it up. This includes misinterpreted words, grammar, and removal of filler words. It is not perfect nor complete (currently at 1hr 30min mark) but hopefully, it will help non-native English speakers understand the video better. I am not sure where to place it, so I decided to create a new folder and place it there. Do let me know if this is useful.